### PR TITLE
MAINT: removes plotting

### DIFF
--- a/diversity/workflows/feature_table_to_pcoa.md
+++ b/diversity/workflows/feature_table_to_pcoa.md
@@ -43,12 +43,3 @@ coordinate analysis.
 >>> import skbio.stats.ordination
 >>> pcoa_results = skbio.stats.ordination.pcoa(distance_matrix)
 ```
-
-This is not how visualizations will be handled in QIIME 2 (track progress in
-[#21](https://github.com/biocore/qiime2/issues/21)), but just an illustration
-that the PCoA results computed here are reasonable:
-
-```python
->>> %matplotlib inline
->>> pcoa_results
-```


### PR DESCRIPTION
This was in place for a demo, but using IPython magic causes a problem when converting to a script. Better to just remove this now since this isn't how we'll handle visualization moving forward ([QIIME2 #21](https://github.com/biocore/qiime2/issues/21)). We can always edit the notebook to visualize there in there future demos that use q2d3. 