### PR TITLE
adds alpha correlation and beta group significance tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip https://github.com/qiime2/q2-feature-table/archive/master.zip
   - pip install .
+  - 'echo "backend: Agg" > matplotlibrc'
 script:
   - nosetests
   - flake8 q2_diversity setup.py

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -7,10 +7,10 @@
 # ----------------------------------------------------------------------------
 
 from ._alpha import alpha, alpha_phylogenetic, alpha_compare
-from ._beta import beta, beta_phylogenetic, bioenv
+from ._beta import beta, beta_phylogenetic, bioenv, beta_group_significance
 from ._ordination import pcoa
 
 __version__ = "0.0.2"
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic', 'pcoa',
-           'alpha_compare', 'bioenv']
+           'alpha_compare', 'bioenv', 'beta_group_significance']

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -6,11 +6,12 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._alpha import alpha, alpha_phylogenetic, alpha_compare
+from ._alpha import alpha, alpha_phylogenetic, alpha_compare, alpha_correlation
 from ._beta import beta, beta_phylogenetic, bioenv, beta_group_significance
 from ._ordination import pcoa
 
 __version__ = "0.0.2"
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic', 'pcoa',
-           'alpha_compare', 'bioenv', 'beta_group_significance']
+           'alpha_compare', 'bioenv', 'beta_group_significance',
+           'alpha_correlation']

--- a/q2_diversity/_alpha.py
+++ b/q2_diversity/_alpha.py
@@ -153,7 +153,8 @@ def alpha_correlation(output_dir: str,
                                               df[alpha_diversity.name])
 
     # generate a scatter plot
-    g = sns.lmplot(x=metadata.name, y=alpha_diversity.name, data=df)
+    g = sns.lmplot(x=metadata.name, y=alpha_diversity.name, data=df,
+                   fit_reg=False)
     g.savefig(os.path.join(output_dir, 'scatter-plot.png'))
     g.savefig(os.path.join(output_dir, 'scatter-plot.pdf'))
 

--- a/q2_diversity/_alpha.py
+++ b/q2_diversity/_alpha.py
@@ -136,12 +136,12 @@ def alpha_correlation(output_dir: str,
                          'options are %s.' %
                          (method, ', '.join(_alpha_correlation_fns.keys())))
 
-    # Cast metadata to numeric, then drop samples that have no data for this
-    # metadata category.
+    # Cast metadata to numeric.
     try:
         metadata = pd.to_numeric(metadata.to_series())
     except ValueError:
-        raise ValueError('Non-numeric data is present in metadata.')
+        raise ValueError('Non-numeric data is present in metadata category %s.'
+                         % metadata.to_series().name)
 
     # create a dataframe containing the data to be correlated, and drop
     # any samples that have no data in either column

--- a/q2_diversity/_alpha.py
+++ b/q2_diversity/_alpha.py
@@ -16,7 +16,6 @@ import pandas as pd
 import seaborn as sns
 import skbio.diversity
 from statsmodels.sandbox.stats.multicomp import multipletests
-import matplotlib.pyplot as plt
 
 
 # We should consider moving these functions to scikit-bio. They're part of

--- a/q2_diversity/_alpha.py
+++ b/q2_diversity/_alpha.py
@@ -16,6 +16,7 @@ import pandas as pd
 import seaborn as sns
 import skbio.diversity
 from statsmodels.sandbox.stats.multicomp import multipletests
+import matplotlib.pyplot as plt
 
 
 # We should consider moving these functions to scikit-bio. They're part of
@@ -119,4 +120,66 @@ def alpha_compare(output_dir: str, alpha_diversity: pd.Series,
                  '\n')
         fh.write(kw_H_pairwise.to_html())
         fh.write('<a href="./kruskal-wallis-pairwise.csv">csv</a>\n')
+        fh.write('</body></html>')
+
+_alpha_correlation_fns = {'spearman': scipy.stats.spearmanr,
+                          'pearson': scipy.stats.pearsonr}
+
+
+def alpha_correlation(output_dir: str,
+                      alpha_diversity: pd.Series,
+                      metadata: qiime.MetadataCategory,
+                      method: str='spearman') -> None:
+    try:
+        alpha_correlation_fn = _alpha_correlation_fns[method]
+    except KeyError:
+        raise ValueError('Unknown alpha correlation method %s. The available '
+                         'options are %s.' %
+                         (method, ', '.join(_alpha_correlation_fns.keys())))
+
+    # Cast metadata to numeric, then drop samples that have no data for this
+    # metadata category.
+    try:
+        metadata = pd.to_numeric(metadata.to_series())
+    except ValueError:
+        raise ValueError('Non-numeric data is present in metadata.')
+
+    # create a dataframe containing the data to be correlated, and drop
+    # any samples that have no data in either column
+    df = pd.concat([metadata, alpha_diversity], axis=1)
+    df.dropna(inplace=True)
+
+    # compute correlation
+    correlation_result = alpha_correlation_fn(df[metadata.name],
+                                              df[alpha_diversity.name])
+
+    # generate a scatter plot
+    g = sns.lmplot(x=metadata.name, y=alpha_diversity.name, data=df)
+    g.savefig(os.path.join(output_dir, 'scatter-plot.png'))
+    g.savefig(os.path.join(output_dir, 'scatter-plot.pdf'))
+
+    index_fp = os.path.join(output_dir, 'index.html')
+    with open(index_fp, 'w') as fh:
+        fh.write('<html><body>')
+        if alpha_diversity.shape[0] != df.shape[0]:
+            fh.write("<b>Warning</b>: Some samples were filtered because they "
+                     "were missing metadata values.<br><b>The input "
+                     "contained %d samples but %s was computed on "
+                     "only %d samples.</b><p>"
+                     % (alpha_diversity.shape[0], method, df.shape[0]))
+        fh.write('<table border=1>\n')
+        fh.write(' <tr><td>Test</td><td>%s correlation</td></tr>\n' %
+                 method.title())
+        fh.write(' <tr><td>Test statistic</td><td>%1.4f</td></tr>\n' %
+                 correlation_result[0])
+        fh.write(' <tr><td>P-value</td><td>%1.4f</td></tr>\n' %
+                 correlation_result[1])
+        fh.write(' <tr><td>Sample size</td><td>%d</td></tr>\n' %
+                 df.shape[0])
+        fh.write('</table>')
+        fh.write('<p>\n')
+        fh.write('<a href="scatter-plot.pdf">\n')
+        fh.write(' <img src="scatter-plot.png">')
+        fh.write(' <p>Download as PDF</p>\n')
+        fh.write('</a>\n\n')
         fh.write('</body></html>')

--- a/q2_diversity/_beta.py
+++ b/q2_diversity/_beta.py
@@ -8,12 +8,15 @@
 
 import os.path
 
+import numpy as np
 import qiime
 import biom
 import skbio
 import skbio.diversity
 import numpy
 import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
 
 
 # We should consider moving these functions to scikit-bio. They're part of
@@ -89,4 +92,82 @@ def bioenv(output_dir: str, distance_matrix: skbio.DistanceMatrix,
                      "only %d samples.</b><p>"
                      % (initial_dm_length, filtered_dm_length))
         fh.write(result.to_html())
+        fh.write('</body></html>')
+
+_beta_group_significance_fns = {'permanova': skbio.stats.distance.permanova,
+                                'anosim': skbio.stats.distance.anosim}
+
+
+def beta_group_significance(output_dir: str,
+                            distance_matrix: skbio.DistanceMatrix,
+                            metadata: qiime.MetadataCategory,
+                            method: str='permanova',
+                            permutations: int=999) -> None:
+    try:
+        beta_group_significance_fn = _beta_group_significance_fns[method]
+    except KeyError:
+        raise ValueError('Unknown group significance method %s. The available '
+                         'options are %s.' %
+                         (method, ', '.join(_beta_group_significance_fns)))
+
+    # Cast metadata to numeric (if applicable), which gives better sorting
+    # in boxplots. Then drop samples with have no data for this metadata
+    # category, including those with empty strings as values.
+    metadata = pd.to_numeric(metadata.to_series(), errors='ignore')
+    metadata = metadata.replace(r'', np.nan).dropna()
+
+    # filter the distance matrix to exclude samples that were dropped from
+    # the metadata, and keep track of how many samples survived the filtering
+    # so that information can be presented to the user.
+    initial_dm_length = distance_matrix.shape[0]
+    distance_matrix = distance_matrix.filter(metadata.index)
+    filtered_dm_length = distance_matrix.shape[0]
+
+    # Run the significance test
+    result = beta_group_significance_fn(distance_matrix, metadata,
+                                        permutations=permutations)
+
+    # Generate distance boxplots
+    # Identify the groups (it would be nice if skbio had a public API for
+    # this, so we'd be sure to have the same groups as as used by the test).
+    grouping = metadata.groupby(metadata)
+    group_distances = []
+    group_ids = []
+    for group_id, group in grouping:
+        group_ids.append(group_id)
+        d = []
+        for i, sid1 in enumerate(group.index):
+            for sid2 in group.index[:i]:
+                d.append(distance_matrix[sid1, sid2])
+        group_distances.append(d)
+    group_distances = list(zip(group_ids, group_distances))
+    group_distances.sort()
+
+    # Plot the within group distances by group
+    ax = sns.boxplot(data=[e[1] for e in group_distances])
+    ax.set_xticklabels(['%s (n=%d)' % (e[0], len(e[1]))
+                        for e in group_distances], rotation=90)
+    ax.set_xlabel(metadata.name)
+    ax.set_ylabel('Within group distances')
+    plt.tight_layout()
+    fig = ax.get_figure()
+    fig.savefig(os.path.join(output_dir, 'boxplots.png'))
+    fig.savefig(os.path.join(output_dir, 'boxplots.pdf'))
+
+    index_fp = os.path.join(output_dir, 'index.html')
+    with open(index_fp, 'w') as fh:
+        fh.write('<html><body>')
+        if initial_dm_length != filtered_dm_length:
+            fh.write("<b>Warning</b>: Some samples were filtered from the "
+                     "input distance matrix because they were missing "
+                     "metadata values.<br><b>The input distance matrix "
+                     "contained %d samples but %s was computed on "
+                     "only %d samples.</b><p>"
+                     % (initial_dm_length, method, filtered_dm_length))
+        fh.write(result.to_frame().to_html())
+        fh.write('<p>\n')
+        fh.write('<a href="boxplots.pdf">\n')
+        fh.write(' <img src="boxplots.png">')
+        fh.write(' <p>Download as PDF</p>\n')
+        fh.write('</a>\n\n')
         fh.write('</body></html>')

--- a/q2_diversity/_beta.py
+++ b/q2_diversity/_beta.py
@@ -8,6 +8,7 @@
 
 import os.path
 import collections
+import urllib.parse
 
 import numpy as np
 import qiime
@@ -139,7 +140,7 @@ def beta_group_significance(output_dir: str,
         raise ValueError('Unknown group significance method %s. The available '
                          'options are %s.' %
                          (method,
-                          ', '.join(_beta_group_significance_fns.keys())))
+                          ', '.join(_beta_group_significance_fns)))
 
     # Cast metadata to numeric (if applicable), which gives better sorting
     # in boxplots. Then filter any samples that are not in the distance matrix,
@@ -186,8 +187,10 @@ def beta_group_significance(output_dir: str,
         sns.despine()
         plt.tight_layout()
         fig = ax.get_figure()
-        fig.savefig(os.path.join(output_dir, '%s-boxplots.png' % group_id))
-        fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' % group_id))
+        fig.savefig(os.path.join(output_dir, '%s-boxplots.png' %
+                                 urllib.parse.quote_plus(str(group_id))))
+        fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' %
+                                 urllib.parse.quote_plus(str(group_id))))
         fig.clear()
 
     index_fp = os.path.join(output_dir, 'index.html')
@@ -203,8 +206,10 @@ def beta_group_significance(output_dir: str,
         fh.write(result.to_frame().to_html())
         for group_id in groupings:
             fh.write('<p>\n')
-            fh.write('<a href="%s-boxplots.pdf">\n' % group_id)
-            fh.write(' <img src="%s-boxplots.png">' % group_id)
+            fh.write('<a href="%s-boxplots.pdf">\n' %
+                     urllib.parse.quote_plus(str(group_id)))
+            fh.write(' <img src="%s-boxplots.png">' %
+                     urllib.parse.quote_plus(str(group_id)))
             fh.write(' <p>Download as PDF</p>\n')
             fh.write('</a>\n\n')
             fh.write('</body></html>')

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -99,7 +99,7 @@ plugin.visualizers.register_function(
 )
 
 beta_group_significance_methods = \
-    list(q2_diversity._beta._beta_group_significance_fns.keys())
+    list(q2_diversity._beta._beta_group_significance_fns)
 
 plugin.visualizers.register_function(
     function=q2_diversity.beta_group_significance,
@@ -113,7 +113,7 @@ plugin.visualizers.register_function(
 )
 
 alpha_correlation_methods = \
-    list(q2_diversity._alpha._alpha_correlation_fns.keys())
+    list(q2_diversity._alpha._alpha_correlation_fns)
 
 plugin.visualizers.register_function(
     function=q2_diversity.alpha_correlation,
@@ -121,8 +121,8 @@ plugin.visualizers.register_function(
     parameters={'method': Str % Choices(alpha_correlation_methods),
                 'metadata': MetadataCategory},
     name='Alpha diversity correlation',
-    description=('Determine whether sample metadata is correlated with '
-                 'alpha diversity.')
+    description=('Determine whether numeric sample metadata category is '
+                 'correlated with alpha diversity.')
 )
 
 plugin.methods.register_markdown('markdown/core_metrics.md')

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -112,4 +112,17 @@ plugin.visualizers.register_function(
                  'different from one another.')
 )
 
+alpha_correlation_methods = \
+    list(q2_diversity._alpha._alpha_correlation_fns.keys())
+
+plugin.visualizers.register_function(
+    function=q2_diversity.alpha_correlation,
+    inputs={'alpha_diversity': SampleData[AlphaDiversity]},
+    parameters={'method': Str % Choices(alpha_correlation_methods),
+                'metadata': MetadataCategory},
+    name='Alpha diversity correlation',
+    description=('Determine whether sample metadata is correlated with '
+                 'alpha diversity.')
+)
+
 plugin.methods.register_markdown('markdown/core_metrics.md')

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime.plugin import (Plugin, Str, Properties, MetadataCategory, Choices,
-                          Metadata)
+                          Metadata, Int)
 
 import q2_diversity
 import q2_diversity._alpha as alpha
@@ -96,6 +96,20 @@ plugin.visualizers.register_function(
                  "dropped. The output visualization will indicate how many "
                  "samples were dropped due to missing data, if any were "
                  "dropped.")
+)
+
+beta_group_significance_methods = \
+    list(q2_diversity._beta._beta_group_significance_fns.keys())
+
+plugin.visualizers.register_function(
+    function=q2_diversity.beta_group_significance,
+    inputs={'distance_matrix': DistanceMatrix},
+    parameters={'method': Str % Choices(beta_group_significance_methods),
+                'permutations': Int,
+                'metadata': MetadataCategory},
+    name='Beta diversity group significance',
+    description=('Determine whether groups of samples are significantly '
+                 'different from one another.')
 )
 
 plugin.methods.register_markdown('markdown/core_metrics.md')

--- a/q2_diversity/tests/test_alpha.py
+++ b/q2_diversity/tests/test_alpha.py
@@ -6,16 +6,19 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
+import tempfile
 import unittest
 
 import io
 import biom
 import skbio
+import qiime
 import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
 
-from q2_diversity import alpha, alpha_phylogenetic
+from q2_diversity import alpha, alpha_phylogenetic, alpha_correlation
 
 
 class AlphaTests(unittest.TestCase):
@@ -72,3 +75,109 @@ class AlphaTests(unittest.TestCase):
             '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
         with self.assertRaises(ValueError):
             alpha_phylogenetic(table=t, phylogeny=tree, metric='not-a-metric')
+
+
+class AlphaCorrelationTests(unittest.TestCase):
+
+    def test_spearman(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', '3.0'], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_correlation(output_dir, alpha_div, md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            pdf_fp = os.path.join(output_dir, 'scatter-plot.pdf')
+            self.assertTrue(os.path.exists(pdf_fp))
+            png_fp = os.path.join(output_dir, 'scatter-plot.png')
+            self.assertTrue(os.path.exists(png_fp))
+
+            self.assertTrue('Spearman correlation' in open(index_fp).read())
+            self.assertTrue('Sample size</td><td>3</td>'
+                            in open(index_fp).read())
+            self.assertFalse('Warning' in open(index_fp).read())
+
+    def test_pearson(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', '3.0'], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_correlation(output_dir, alpha_div, md, method='pearson')
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            pdf_fp = os.path.join(output_dir, 'scatter-plot.pdf')
+            self.assertTrue(os.path.exists(pdf_fp))
+            png_fp = os.path.join(output_dir, 'scatter-plot.png')
+            self.assertTrue(os.path.exists(png_fp))
+
+            self.assertTrue('Pearson correlation' in open(index_fp).read())
+            self.assertTrue('Sample size</td><td>3</td>'
+                            in open(index_fp).read())
+            self.assertFalse('Warning' in open(index_fp).read())
+
+    def test_bad_method(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', '3.0'], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(ValueError):
+                alpha_correlation(output_dir, alpha_div, md, method='bad!')
+
+    def test_bad_metadata(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['a', 'b', 'c'], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaises(ValueError):
+                alpha_correlation(output_dir, alpha_div, md)
+
+    def test_nan_metadata(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', ''], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_correlation(output_dir, alpha_div, md)
+            index_fp = os.path.join(output_dir, 'index.html')
+
+            self.assertTrue('Sample size</td><td>2</td>'
+                            in open(index_fp).read())
+            self.assertTrue('Warning' in open(index_fp).read())
+            self.assertTrue('contained 3 samples' in open(index_fp).read())
+            self.assertTrue('only 2 samples' in open(index_fp).read())
+
+    def test_extra_metadata(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', '3.0', '4.0'], name='value',
+                      index=['sample1', 'sample2', 'sample3', 'sample4']))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_correlation(output_dir, alpha_div, md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('Sample size</td><td>3' in open(index_fp).read())
+
+    def test_extra_alpha_div(self):
+        alpha_div = pd.Series([2.0, 4.0, 6.0, 8.0], name='alpha-div',
+                              index=['sample1', 'sample2', 'sample3',
+                                     'sample4'])
+        md = qiime.MetadataCategory(
+            pd.Series(['1.0', '2.0', '3.0'], name='value',
+                      index=['sample1', 'sample2', 'sample3']))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_correlation(output_dir, alpha_div, md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            self.assertTrue('Sample size</td><td>3' in open(index_fp).read())

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -10,6 +10,7 @@ import unittest
 import io
 import os
 import tempfile
+import glob
 
 import skbio
 import numpy as np
@@ -146,10 +147,20 @@ class BetaGroupSignificanceTests(unittest.TestCase):
             beta_group_significance(output_dir, dm, md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            pdf_fp = os.path.join(output_dir, 'boxplots.pdf')
-            self.assertTrue(os.path.exists(pdf_fp))
-            png_fp = os.path.join(output_dir, 'boxplots.png')
-            self.assertTrue(os.path.exists(png_fp))
+            # all expected boxplots are generated
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.png')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.png')))
+            # no extra boxplots are generated
+            self.assertEqual(len(glob.glob('%s/*-boxplots.pdf' % output_dir)),
+                             2)
+            self.assertEqual(len(glob.glob('%s/*-boxplots.png' % output_dir)),
+                             2)
             self.assertTrue('PERMANOVA results' in open(index_fp).read())
             self.assertFalse('Warning' in open(index_fp).read())
 
@@ -167,10 +178,20 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                     permutations=42)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            pdf_fp = os.path.join(output_dir, 'boxplots.pdf')
-            self.assertTrue(os.path.exists(pdf_fp))
-            png_fp = os.path.join(output_dir, 'boxplots.png')
-            self.assertTrue(os.path.exists(png_fp))
+            # all expected boxplots are generated
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.png')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.png')))
+            # no extra boxplots are generated
+            self.assertEqual(len(glob.glob('%s/*-boxplots.pdf' % output_dir)),
+                             2)
+            self.assertEqual(len(glob.glob('%s/*-boxplots.png' % output_dir)),
+                             2)
             self.assertTrue('ANOSIM results' in open(index_fp).read())
             self.assertTrue('<td>42</td>' in open(index_fp).read())
             self.assertFalse('Warning' in open(index_fp).read())
@@ -231,6 +252,20 @@ class BetaGroupSignificanceTests(unittest.TestCase):
             beta_group_significance(output_dir, dm, md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue('Warning' in open(index_fp).read())
+
+    def test_extra_metadata(self):
+        dm = skbio.DistanceMatrix([[0.00, 0.25, 0.25],
+                                   [0.25, 0.00, 0.00],
+                                   [0.25, 0.00, 0.00]],
+                                  ids=['sample1', 'sample2', 'sample3'])
+        md = qiime.MetadataCategory(
+            pd.Series(['a', 'b', 'b', 'c'], name='a or b',
+                      index=['sample1', 'sample2', 'sample3', 'sample4']))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            beta_group_significance(output_dir, dm, md, permutations=42)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue('<td>2</td>' in open(index_fp).read())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
partially address #17 

* Adds beta_group_significance, which supports running anosim and permanova (default) to test for grouping of samples by metadata. Resulting visualization looks like:

![screenshot 2016-10-05 09 12 59](https://cloud.githubusercontent.com/assets/192372/19121601/f868abd6-8adb-11e6-8546-733adc969577.png)


* Adds alpha_correlation, which supports running pearson or spearman (default) to test for correlations between alpha diversity and sample metadata. Resulting visualization looks like:

![screenshot 2016-10-04 17 43 36](https://cloud.githubusercontent.com/assets/192372/19097544/6e92977c-8a5a-11e6-81c2-3c39d84313f4.png)






