### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION nose flake8 scikit-bio seaborn statsmodels
+  - conda create --yes -n test-env -c biocore python=$PYTHON_VERSION nose scikit-bio seaborn statsmodels
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip https://github.com/qiime2/q2templates/archive/master.zip https://github.com/qiime2/q2-feature-table/archive/master.zip
   - pip install .
+  - pip install flake8
   - 'echo "backend: Agg" > matplotlibrc'
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_diversity setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME 2 Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of diversity nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -1,10 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+
+import pkg_resources
 
 from ._alpha import (alpha, alpha_phylogenetic, alpha_group_significance,
                      alpha_correlation)
@@ -12,7 +14,8 @@ from ._beta import beta, beta_phylogenetic, bioenv, beta_group_significance
 from ._ordination import pcoa
 from ._core_metrics import core_metrics
 
-__version__ = "0.0.7.dev0"
+
+__version__ = pkg_resources.get_distribution('q2-diversity').version
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic', 'pcoa',
            'alpha_group_significance', 'bioenv', 'beta_group_significance',

--- a/q2_diversity/_alpha/__init__.py
+++ b/q2_diversity/_alpha/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -15,7 +15,7 @@ from urllib.parse import quote
 import scipy
 import numpy as np
 import pandas as pd
-import qiime
+import qiime2
 from statsmodels.sandbox.stats.multicomp import multipletests
 import q2templates
 
@@ -24,7 +24,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_diversity', '_alpha')
 
 
 def alpha_group_significance(output_dir: str, alpha_diversity: pd.Series,
-                             metadata: qiime.Metadata) -> None:
+                             metadata: qiime2.Metadata) -> None:
     metadata_df = metadata.to_dataframe()
     metadata_df = metadata_df.apply(pd.to_numeric, errors='ignore')
     pre_filtered_cols = set(metadata_df.columns)
@@ -119,7 +119,7 @@ _alpha_correlation_fns = {'spearman': scipy.stats.spearmanr,
 
 def alpha_correlation(output_dir: str,
                       alpha_diversity: pd.Series,
-                      metadata: qiime.Metadata,
+                      metadata: qiime2.Metadata,
                       method: str='spearman') -> None:
     try:
         alpha_correlation_fn = _alpha_correlation_fns[method]

--- a/q2_diversity/_beta/__init__.py
+++ b/q2_diversity/_beta/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,7 +11,7 @@ import collections
 import urllib.parse
 import pkg_resources
 
-import qiime
+import qiime2
 import skbio
 import skbio.diversity
 import numpy
@@ -25,7 +25,7 @@ TEMPLATES = pkg_resources.resource_filename('q2_diversity', '_beta')
 
 
 def bioenv(output_dir: str, distance_matrix: skbio.DistanceMatrix,
-           metadata: qiime.Metadata) -> None:
+           metadata: qiime2.Metadata) -> None:
     # convert metadata to numeric values where applicable, drop the non-numeric
     # values, and then drop samples that contain NaNs
     df = metadata.to_dataframe()
@@ -95,7 +95,7 @@ def _get_distance_boxplot_data(distance_matrix, group_id, groupings):
 
 def beta_group_significance(output_dir: str,
                             distance_matrix: skbio.DistanceMatrix,
-                            metadata: qiime.MetadataCategory,
+                            metadata: qiime2.MetadataCategory,
                             method: str='permanova',
                             permutations: int=999) -> None:
     try:

--- a/q2_diversity/_core_metrics.py
+++ b/q2_diversity/_core_metrics.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/_ordination.py
+++ b/q2_diversity/_ordination.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -1,19 +1,22 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import (Plugin, Str, Properties, MetadataCategory, Choices,
-                          Metadata, Int)
+from qiime2.plugin import (Plugin, Str, Properties, MetadataCategory, Choices,
+                           Metadata, Int)
 
 import q2_diversity
 from q2_diversity import _alpha as alpha
 from q2_diversity import _beta as beta
-from q2_types import (FeatureTable, Frequency, DistanceMatrix, AlphaDiversity,
-                      PCoAResults, SampleData, Phylogeny, Rooted)
+from q2_types.feature_table import FeatureTable, Frequency
+from q2_types.distance_matrix import DistanceMatrix
+from q2_types.sample_data import AlphaDiversity, SampleData
+from q2_types.tree import Phylogeny, Rooted
+from q2_types.ordination import PCoAResults
 
 
 plugin = Plugin(

--- a/q2_diversity/tests/test_alpha.py
+++ b/q2_diversity/tests/test_alpha.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -13,7 +13,7 @@ import unittest
 import io
 import biom
 import skbio
-import qiime
+import qiime2
 import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
@@ -96,7 +96,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_spearman(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['1.0', '2.0', '3.0']},
                          index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -114,7 +114,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_pearson(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['1.0', '2.0', '3.0']},
                          index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -132,7 +132,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_bad_method(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['1.0', '2.0', '3.0'], name='value',
                       index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -142,7 +142,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_bad_metadata(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['a', 'b', 'c']},
                          index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -152,7 +152,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_nan_metadata(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['1.0', '2.0', '']},
                          index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -168,7 +168,7 @@ class AlphaCorrelationTests(unittest.TestCase):
     def test_extra_metadata(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['1.0', '2.0', '3.0', '4.0']},
                          index=['sample1', 'sample2', 'sample3', 'sample4']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -184,7 +184,7 @@ class AlphaCorrelationTests(unittest.TestCase):
         alpha_div = pd.Series([2.0, 4.0, 6.0, 8.0], name='alpha-div',
                               index=['sample1', 'sample2', 'sample3',
                                      'sample4'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame({'value': ['1.0', '2.0', '3.0']},
                          index=['sample1', 'sample2', 'sample3']))
         with tempfile.TemporaryDirectory() as output_dir:

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -18,7 +18,7 @@ import numpy as np
 import numpy.testing as npt
 from biom.table import Table
 import pandas as pd
-import qiime
+import qiime2
 
 from q2_diversity import (beta, beta_phylogenetic, bioenv,
                           beta_group_significance)
@@ -115,7 +115,7 @@ class BioenvTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame([['1.0', 'a'], ['2.0', 'b'], ['3.0', 'c']],
                          index=['sample1', 'sample2', 'sample3'],
                          columns=['metadata1', 'metadata2']))
@@ -135,7 +135,7 @@ class BioenvTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame([['1.0', '2.0'], ['2.0', ''], ['3.0', '42.0']],
                          index=['sample1', 'sample2', 'sample3'],
                          columns=['metadata1', 'metadata2']))
@@ -154,7 +154,7 @@ class BioenvTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame([['1.0', 'a'], ['2.0', 'b'], ['3.0', 'c'],
                           ['4.0', 'd']],
                          index=['sample1', 'sample2', 'sample3', 'sample4'],
@@ -175,7 +175,7 @@ class BioenvTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.Metadata(
+        md = qiime2.Metadata(
             pd.DataFrame([['1.0', '2.0'], ['2.0', '2.0'], ['3.0', '2.0']],
                          index=['sample1', 'sample2', 'sample3'],
                          columns=['metadata1', 'metadata2']))
@@ -197,7 +197,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b'], name='a or b',
                       index=['sample1', 'sample2', 'sample3']))
 
@@ -227,7 +227,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b'], name='a or b',
                       index=['sample1', 'sample2', 'sample3']))
 
@@ -259,7 +259,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b'], name='a or b',
                       index=['sample1', 'sample2', 'sample3']))
 
@@ -273,7 +273,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b'], name='a or b',
                       index=['sample1', 'sample2', 'sample3']))
 
@@ -288,7 +288,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.66, 0.66, 0.66, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3',
                                        'sample4'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['1.0', '2.0', '2.0', ''], name='a or b',
                       index=['sample1', 'sample2', 'sample3', 'sample4']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -303,7 +303,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.66, 0.66, 0.66, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3',
                                        'sample4'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b', ''], name='a or b',
                       index=['sample1', 'sample2', 'sample3', 'sample4']))
         with tempfile.TemporaryDirectory() as output_dir:
@@ -316,7 +316,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                                    [0.25, 0.00, 0.00],
                                    [0.25, 0.00, 0.00]],
                                   ids=['sample1', 'sample2', 'sample3'])
-        md = qiime.MetadataCategory(
+        md = qiime2.MetadataCategory(
             pd.Series(['a', 'b', 'b', 'c'], name='a or b',
                       index=['sample1', 'sample2', 'sample3', 'sample4']))
 
@@ -388,6 +388,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
         exp_labels = ['g1 (n=1)', 'g3 (n=2)', 'g2 (n=4)']
         self.assertEqual(obs[0], exp_data)
         self.assertEqual(obs[1], exp_labels)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_diversity/tests/test_ordination.py
+++ b/q2_diversity/tests/test_ordination.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,13 +10,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-diversity",
-    # TODO stop duplicating version string
-    version="0.0.7.dev0",
+    version="2017.2.0.dev0",
     packages=find_packages(),
-    install_requires=['qiime >= 2.0.6', 'q2-feature-table >= 0.0.6',
-                      'q2-types >= 0.0.6', 'scikit-bio', 'seaborn',
-                      'statsmodels', 'scipy', 'numpy', 'pandas',
-                      'biom-format >= 2.1.5, < 2.2.0', 'q2templates >= 0.0.6'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-feature-table == 2017.2.*',
+                      'q2-types == 2017.2.*', 'q2templates == 2017.2.*',
+                      'scikit-bio', 'seaborn', 'statsmodels', 'scipy', 'numpy',
+                      'pandas', 'biom-format >= 2.1.5, < 2.2.0'],
     package_data={'q2_diversity._alpha': [
                       'alpha_group_significance_assets/index.html',
                       'alpha_group_significance_assets/dst/*',
@@ -30,8 +29,8 @@ setup(
     author_email="gregcaporaso@gmail.com",
     description="Core diversity analyses.",
     license='BSD-3-Clause',
-    url="http://www.qiime.org",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins': ['q2-diversity=q2_diversity.plugin_setup:plugin']
+        'qiime2.plugins': ['q2-diversity=q2_diversity.plugin_setup:plugin']
     }
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.