### PR TITLE
ENH: add filter-distance-matrix method

### DIFF
--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -13,10 +13,11 @@ from ._alpha import (alpha, alpha_phylogenetic, alpha_group_significance,
 from ._beta import beta, beta_phylogenetic, bioenv, beta_group_significance
 from ._ordination import pcoa
 from ._core_metrics import core_metrics
+from ._filter import filter_distance_matrix
 
 
 __version__ = pkg_resources.get_distribution('q2-diversity').version
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic', 'pcoa',
            'alpha_group_significance', 'bioenv', 'beta_group_significance',
-           'alpha_correlation', 'core_metrics']
+           'alpha_correlation', 'core_metrics', 'filter_distance_matrix']

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -1,0 +1,24 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import skbio
+import qiime2
+
+
+def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
+                           sample_metadata: qiime2.Metadata,
+                           where: str=None) -> skbio.DistanceMatrix:
+    ids_to_keep = sample_metadata.ids(where=where)
+    # NOTE: there is no guaranteed ordering to output distance matrix because
+    # `ids_to_keep` is a set, and `DistanceMatrix.filter` uses its iteration
+    # order.
+    try:
+        return distance_matrix.filter(ids_to_keep, strict=False)
+    except skbio.stats.distance.DissimilarityMatrixError:
+        raise ValueError(
+            "All samples were filtered out of the distance matrix.")

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import qiime2
 from qiime2.plugin import (Plugin, Str, Properties, MetadataCategory, Choices,
                            Metadata, Int)
 
@@ -103,6 +104,43 @@ plugin.methods.register_function(
     ],
     name='Core diversity metrics',
     description="Applies a collection of diversity metrics to a feature table."
+)
+
+plugin.methods.register_function(
+    function=q2_diversity.filter_distance_matrix,
+    inputs={
+        'distance_matrix': DistanceMatrix
+    },
+    parameters={
+        'sample_metadata': Metadata,
+        'where': Str
+    },
+    outputs=[
+        ('filtered_distance_matrix', DistanceMatrix)
+    ],
+    name="Filter samples from a distance matrix",
+    description="Filter samples from a distance matrix, retaining only the "
+                "samples matching search criteria specified by "
+                "`sample_metadata` and `where` parameters. See the filtering "
+                "tutorial for additional details: "
+                "https://docs.qiime2.org/%s/tutorials/filtering/"
+                % qiime2.__version__,
+    input_descriptions={
+        'distance_matrix': 'Distance matrix to filter'
+    },
+    parameter_descriptions={
+        'sample_metadata': 'Sample metadata used in conjuction with `where` '
+                           'parameter to select samples to retain',
+        'where': 'SQLite WHERE clause specifying sample metadata criteria '
+                 'that must be met to be included in the filtered distance '
+                 'matrix. If not provided, all samples in `sample_metadata` '
+                 'that are also in the input distance matrix will be '
+                 'retained.'
+    },
+    output_descriptions={
+        'filtered_distance_matrix': 'Distance matrix filtered to include '
+                                    'samples matching search criteria'
+    }
 )
 
 plugin.visualizers.register_function(

--- a/q2_diversity/tests/test_filter.py
+++ b/q2_diversity/tests/test_filter.py
@@ -1,0 +1,140 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2017, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import numpy as np
+import pandas as pd
+import qiime2
+import skbio
+
+from q2_diversity import filter_distance_matrix
+
+
+class TestFilterDistanceMatrix(unittest.TestCase):
+    def _sorted(self, dm):
+        ids = np.array(dm.ids)
+        order = np.argsort(ids)
+        return skbio.DistanceMatrix(dm[order][:, order], ids[order])
+
+    def test_without_where_no_filtering(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(dm, metadata)
+
+        # There is no guaranteed order to output. Sort by ID before comparing
+        # to expected.
+        self.assertEqual(self._sorted(filtered), dm)
+
+    def test_without_where_extra_ids(self):
+        df = pd.DataFrame(
+            {'Subject': ['subject-1', 'subject-1', 'subject-2', 'subject-2'],
+             'SampleType': ['gut', 'tongue', 'gut', 'tongue']},
+            index=['S1', 'S4', 'S2', 'S5'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(dm, metadata)
+
+        expected = skbio.DistanceMatrix([[0, 1], [1, 0]], ['S1', 'S2'])
+        self.assertEqual(self._sorted(filtered), expected)
+
+    def test_without_where_all_filtered(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S4', 'S5', 'S6'])
+
+        with self.assertRaisesRegex(ValueError, 'All samples.*filtered'):
+            filter_distance_matrix(dm, metadata)
+
+    def test_without_where_some_filtered(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1'],
+                           'SampleType': ['gut', 'tongue']},
+                          index=['S1', 'S2'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(dm, metadata)
+
+        expected = skbio.DistanceMatrix([[0, 1], [1, 0]], ['S1', 'S2'])
+        self.assertEqual(self._sorted(filtered), expected)
+
+    def test_with_where_no_filtering(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(
+            dm, metadata, where="SampleType='gut' OR SampleType='tongue'")
+
+        self.assertEqual(self._sorted(filtered), dm)
+
+    def test_with_where_extra_ids(self):
+        df = pd.DataFrame(
+            {'Subject': ['subject-1', 'subject-1', 'subject-2', 'subject-2'],
+             'SampleType': ['gut', 'tongue', 'gut', 'tongue']},
+            index=['S1', 'S4', 'S2', 'S5'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(
+            dm, metadata, where="SampleType='gut' OR SampleType='tongue'")
+
+        expected = skbio.DistanceMatrix([[0, 1], [1, 0]], ['S1', 'S2'])
+        self.assertEqual(self._sorted(filtered), expected)
+
+    def test_with_where_all_filtered(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        with self.assertRaisesRegex(ValueError, 'All samples.*filtered'):
+            filter_distance_matrix(dm, metadata, where="SampleType='palm'")
+
+    def test_with_where_some_filtered(self):
+        df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
+                           'SampleType': ['gut', 'tongue', 'gut']},
+                          index=['S1', 'S2', 'S3'])
+        metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
+        filtered = filter_distance_matrix(dm, metadata,
+                                          where="Subject='subject-2'")
+
+        expected = skbio.DistanceMatrix([[0]], ['S3'])
+        self.assertEqual(filtered, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Supports filtering samples based on index or metadata (similar to filtering feature tables).