### PR TITLE
ENH: adds optional pairwise beta group significance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: python
 env:
   - PYTHON_VERSION=3.5

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -191,16 +191,18 @@ def beta_group_significance(output_dir: str,
             pairwise_results.append([group1_id,
                                      group2_id,
                                      pairwise_result['sample size'],
+                                     permutations,
                                      pairwise_result['test statistic'],
                                      pairwise_result['p-value']])
-        columns = ['Group 1', 'Group 2', 'Sample size',
+        columns = ['Group 1', 'Group 2', 'Sample size', 'Permutations',
                    result['test statistic name'], 'p-value']
         pairwise_results = pd.DataFrame(pairwise_results, columns=columns)
         pairwise_results.set_index(['Group 1', 'Group 2'], inplace=True)
         pairwise_results['q-value'] = multipletests(
             pairwise_results['p-value'], method='fdr_bh')[1]
         pairwise_results.sort_index(inplace=True)
-        pairwise_path = os.path.join(output_dir, 'pairwise.csv')
+        pairwise_path = os.path.join(
+            output_dir, '%s-pairwise.csv' % method)
         pairwise_results.to_csv(pairwise_path)
 
         pairwise_results_html = pairwise_results.to_html(

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -10,6 +10,7 @@ import os.path
 import collections
 import urllib.parse
 import pkg_resources
+import itertools
 
 import qiime2
 import skbio
@@ -19,6 +20,7 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 import q2templates
+from statsmodels.sandbox.stats.multicomp import multipletests
 
 
 TEMPLATES = pkg_resources.resource_filename('q2_diversity', '_beta')
@@ -93,10 +95,21 @@ def _get_distance_boxplot_data(distance_matrix, group_id, groupings):
     return all_group_distances, x_ticklabels
 
 
+def _get_pairwise_group_significance_stats(
+        distance_matrix, group1_id, group2_id, groupings, metadata,
+        beta_group_significance_fn, permutations):
+    group1_group2_samples = groupings[group1_id] + groupings[group2_id]
+    metadata = metadata[group1_group2_samples]
+    distance_matrix = distance_matrix.filter(group1_group2_samples)
+    return beta_group_significance_fn(distance_matrix, metadata,
+                                      permutations=permutations)
+
+
 def beta_group_significance(output_dir: str,
                             distance_matrix: skbio.DistanceMatrix,
                             metadata: qiime2.MetadataCategory,
                             method: str='permanova',
+                            pairwise: bool=False,
                             permutations: int=999) -> None:
     try:
         beta_group_significance_fn = _beta_group_significance_fns[method]
@@ -159,9 +172,44 @@ def beta_group_significance(output_dir: str,
                                  urllib.parse.quote_plus(str(group_id))))
         fig.clear()
 
-    result = result.to_frame().to_html(classes="table table-striped "
-                                       "table-hover")
-    result = result.replace('border="1"', 'border="0"')
+    result_html = result.to_frame().to_html(classes=("table table-striped "
+                                                     "table-hover"))
+    result_html = result_html.replace('border="1"', 'border="0"')
+
+    if pairwise:
+        pairwise_results = []
+        for group1_id, group2_id in itertools.combinations(groupings, 2):
+            pairwise_result = \
+                _get_pairwise_group_significance_stats(
+                    distance_matrix=distance_matrix,
+                    group1_id=group1_id,
+                    group2_id=group2_id,
+                    groupings=groupings,
+                    metadata=metadata,
+                    beta_group_significance_fn=beta_group_significance_fn,
+                    permutations=permutations)
+            pairwise_results.append([group1_id,
+                                     group2_id,
+                                     pairwise_result['sample size'],
+                                     pairwise_result['test statistic'],
+                                     pairwise_result['p-value']])
+        columns = ['Group 1', 'Group 2', 'Sample size',
+                   result['test statistic name'], 'p-value']
+        pairwise_results = pd.DataFrame(pairwise_results, columns=columns)
+        pairwise_results.set_index(['Group 1', 'Group 2'], inplace=True)
+        pairwise_results['q-value'] = multipletests(
+            pairwise_results['p-value'], method='fdr_bh')[1]
+        pairwise_results.sort_index(inplace=True)
+        pairwise_path = os.path.join(output_dir, 'pairwise.csv')
+        pairwise_results.to_csv(pairwise_path)
+
+        pairwise_results_html = pairwise_results.to_html(
+            classes=("table table-striped table-hover"))
+        pairwise_results_html = pairwise_results_html.replace(
+            'border="1"', 'border="0"')
+    else:
+        pairwise_results_html = None
+
     index = os.path.join(
         TEMPLATES, 'beta_group_significance_assets', 'index.html')
     q2templates.render(index, output_dir, context={
@@ -169,5 +217,6 @@ def beta_group_significance(output_dir: str,
         'filtered_dm_length': filtered_dm_length,
         'method': method,
         'groupings': groupings,
-        'result': result
+        'result': result_html,
+        'pairwise_results': pairwise_results_html
     })

--- a/q2_diversity/_beta/beta_group_significance_assets/index.html
+++ b/q2_diversity/_beta/beta_group_significance_assets/index.html
@@ -26,7 +26,7 @@
       {% if pairwise_results %}
         <hr>
         <h2>Pairwise {{ method }} results</h2>
-        <a href="pairwise.csv">Download CSV</a>
+        <a href="{{ method }}-pairwise.csv">Download CSV</a>
         {{ pairwise_results }}
       {% endif %}
     </div>

--- a/q2_diversity/_beta/beta_group_significance_assets/index.html
+++ b/q2_diversity/_beta/beta_group_significance_assets/index.html
@@ -13,6 +13,7 @@
   <div class="row">
     <div class="col-lg-12">
       {{ result }}
+      <hr>
       {% for group_id in groupings %}
       <div class="text-center">
         <a href="{{ group_id | replace(' ', '+') }}-boxplots.pdf">
@@ -21,8 +22,13 @@
           <p>Download as PDF</p>
         </a>
       </div>
-      <hr>
       {% endfor %}
+      {% if pairwise_results %}
+        <hr>
+        <h2>Pairwise {{ method }} results</h2>
+        <a href="pairwise.csv">Download CSV</a>
+        {{ pairwise_results }}
+      {% endif %}
     </div>
   </div>
 

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -7,7 +7,7 @@
 # ----------------------------------------------------------------------------
 
 from qiime2.plugin import (Plugin, Str, Properties, MetadataCategory, Choices,
-                           Metadata, Int)
+                           Metadata, Int, Bool)
 
 import q2_diversity
 from q2_diversity import _alpha as alpha
@@ -274,7 +274,8 @@ plugin.visualizers.register_function(
     inputs={'distance_matrix': DistanceMatrix},
     parameters={'method': Str % Choices(beta_group_significance_methods),
                 'permutations': Int,
-                'metadata': MetadataCategory},
+                'metadata': MetadataCategory,
+                'pairwise': Bool},
     input_descriptions={
         'distance_matrix': 'Matrix of distances between pairs of samples.'
     },
@@ -282,7 +283,11 @@ plugin.visualizers.register_function(
         'method': 'The group significance test to be applied.',
         'permutations': ('The number of permutations to be run when computing '
                          'p-values.'),
-        'metadata': 'The sample metadata.'
+        'metadata': 'The sample metadata.',
+        'pairwise': ('Perform pairwise tests between all pairs of groups '
+                     'in addition to the test across all groups. '
+                     'This can be very slow if there are a lot of groups '
+                     'in the category.')
     },
     name='Beta diversity group significance',
     description=('Determine whether groups of samples are significantly '

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -221,6 +221,7 @@ class BetaGroupSignificanceTests(unittest.TestCase):
                              2)
             self.assertTrue('PERMANOVA results' in open(index_fp).read())
             self.assertFalse('Warning' in open(index_fp).read())
+            self.assertFalse('Pairwise permanova' in open(index_fp).read())
 
     def test_anosim(self):
         dm = skbio.DistanceMatrix([[0.00, 0.25, 0.25],
@@ -253,6 +254,71 @@ class BetaGroupSignificanceTests(unittest.TestCase):
             self.assertTrue('ANOSIM results' in open(index_fp).read())
             self.assertTrue('<td>42</td>' in open(index_fp).read())
             self.assertFalse('Warning' in open(index_fp).read())
+            self.assertFalse('Pairwise anosim' in open(index_fp).read())
+
+    def test_permanova_pairwise(self):
+        dm = skbio.DistanceMatrix([[0.00, 0.25, 0.25],
+                                   [0.25, 0.00, 0.00],
+                                   [0.25, 0.00, 0.00]],
+                                  ids=['sample1', 'sample2', 'sample3'])
+        md = qiime2.MetadataCategory(
+            pd.Series(['a', 'b', 'b'], name='a or b',
+                      index=['sample1', 'sample2', 'sample3']))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            beta_group_significance(output_dir, dm, md, pairwise=True)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            # all expected boxplots are generated
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.png')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.png')))
+            # no extra boxplots are generated
+            self.assertEqual(len(glob.glob('%s/*-boxplots.pdf' % output_dir)),
+                             2)
+            self.assertEqual(len(glob.glob('%s/*-boxplots.png' % output_dir)),
+                             2)
+            self.assertTrue('PERMANOVA results' in open(index_fp).read())
+            self.assertTrue('Pairwise permanova' in open(index_fp).read())
+            self.assertFalse('Warning' in open(index_fp).read())
+
+    def test_anosim_pairwise(self):
+        dm = skbio.DistanceMatrix([[0.00, 0.25, 0.25],
+                                   [0.25, 0.00, 0.00],
+                                   [0.25, 0.00, 0.00]],
+                                  ids=['sample1', 'sample2', 'sample3'])
+        md = qiime2.MetadataCategory(
+            pd.Series(['a', 'b', 'b'], name='a or b',
+                      index=['sample1', 'sample2', 'sample3']))
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            beta_group_significance(output_dir, dm, md, method='anosim',
+                                    permutations=42, pairwise=True)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            # all expected boxplots are generated
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'a-boxplots.png')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.pdf')))
+            self.assertTrue(os.path.exists(
+                            os.path.join(output_dir, 'b-boxplots.png')))
+            # no extra boxplots are generated
+            self.assertEqual(len(glob.glob('%s/*-boxplots.pdf' % output_dir)),
+                             2)
+            self.assertEqual(len(glob.glob('%s/*-boxplots.png' % output_dir)),
+                             2)
+            self.assertTrue('ANOSIM results' in open(index_fp).read())
+            self.assertTrue('<td>42</td>' in open(index_fp).read())
+            self.assertFalse('Warning' in open(index_fp).read())
+            self.assertTrue('Pairwise anosim' in open(index_fp).read())
 
     def test_alt_permutations(self):
         dm = skbio.DistanceMatrix([[0.00, 0.25, 0.25],


### PR DESCRIPTION
fixes #50 

[Here's](https://dl.dropboxusercontent.com/u/2868868/temp/unweighted-unifrac-body-site-pairwise-significance.qzv) an example .qzv with the pairwise tests.

I've confirmed that the .qzv looks right when computed with ANOSIM (some of the descriptions of values change), and when it is run without the pairwise tests. 

Pairwise tests are off by default since they can be very slow. 