### PR TITLE
ENH: Support for negating distance matrix filtering

### DIFF
--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -20,7 +20,7 @@ def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
     # order.
     try:
         filtered = distance_matrix.filter(ids_to_keep, strict=False)
-        if exclude_ids is True:
+        if exclude_ids:
             ids_to_keep = set(distance_matrix.ids) - set(filtered.ids)
             filtered = distance_matrix.filter(ids_to_keep, strict=False)
         return filtered

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -19,15 +19,9 @@ def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
     # `ids_to_keep` is a set, and `DistanceMatrix.filter` uses its iteration
     # order.
     try:
-        filtered = distance_matrix.filter(ids_to_keep, strict=False)
         if exclude_ids:
-            ids_to_keep = set(distance_matrix.ids) - set(filtered.ids)
-            filtered = distance_matrix.filter(ids_to_keep, strict=False)
-        return filtered
+            ids_to_keep = set(distance_matrix.ids) - set(ids_to_keep)
+        return distance_matrix.filter(ids_to_keep, strict=False)
     except skbio.stats.distance.DissimilarityMatrixError:
-        if (exclude_ids and ids_to_keep and
-                set(ids_to_keep).isdisjoint(distance_matrix.ids)):
-            return distance_matrix
-        else:
-            raise ValueError("All samples were filtered out of the "
-                             "distance matrix.")
+        raise ValueError("All samples were filtered out of the "
+                         "distance matrix.")

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -15,11 +15,11 @@ def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
                            where: str=None,
                            exclude_ids: bool=False) -> skbio.DistanceMatrix:
     ids_to_keep = metadata.ids(where=where)
+    if exclude_ids:
+        ids_to_keep = set(distance_matrix.ids) - set(ids_to_keep)
     # NOTE: there is no guaranteed ordering to output distance matrix because
     # `ids_to_keep` is a set, and `DistanceMatrix.filter` uses its iteration
     # order.
-    if exclude_ids:
-        ids_to_keep = set(distance_matrix.ids) - set(ids_to_keep)
     try:
         return distance_matrix.filter(ids_to_keep, strict=False)
     except skbio.stats.distance.DissimilarityMatrixError:

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -26,7 +26,7 @@ def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
         return filtered
     except skbio.stats.distance.DissimilarityMatrixError:
         if (exclude_ids and ids_to_keep and
-                not bool(set(ids_to_keep) & set(distance_matrix.ids))):
+                set(ids_to_keep).isdisjoint(distance_matrix.ids)):
             return distance_matrix
         else:
             raise ValueError("All samples were filtered out of the "

--- a/q2_diversity/_filter.py
+++ b/q2_diversity/_filter.py
@@ -18,10 +18,10 @@ def filter_distance_matrix(distance_matrix: skbio.DistanceMatrix,
     # NOTE: there is no guaranteed ordering to output distance matrix because
     # `ids_to_keep` is a set, and `DistanceMatrix.filter` uses its iteration
     # order.
+    if exclude_ids:
+        ids_to_keep = set(distance_matrix.ids) - set(ids_to_keep)
     try:
-        if exclude_ids:
-            ids_to_keep = set(distance_matrix.ids) - set(ids_to_keep)
         return distance_matrix.filter(ids_to_keep, strict=False)
     except skbio.stats.distance.DissimilarityMatrixError:
-        raise ValueError("All samples were filtered out of the "
-                         "distance matrix.")
+        raise ValueError(
+            "All samples were filtered out of the distance matrix.")

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -233,7 +233,7 @@ plugin.methods.register_function(
                  'also in the input distance matrix will be retained.',
         'exclude_ids': 'If `True`, returns the filtered distance matrix '
                        'containing the set of samples which occur in the '
-                       'feature table but not in the metadata (or the '
+                       'distance matrix but not in the metadata (or the '
                        'filtered metadata, if invoked in conjunction with '
                        '`where`).'
     },

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -225,17 +225,16 @@ plugin.methods.register_function(
         'distance_matrix': 'Distance matrix to filter by sample.'
     },
     parameter_descriptions={
-        'metadata': 'Sample metadata used in conjuction with `where` '
-                    'parameter to select samples to retain',
+        'metadata': 'Sample metadata used with `where` parameter when '
+                    'selecting samples to retain, or with `exclude_ids` '
+                    'when selecting samples to discard.',
         'where': 'SQLite WHERE clause specifying sample metadata criteria '
                  'that must be met to be included in the filtered distance '
                  'matrix. If not provided, all samples in `metadata` that are '
                  'also in the input distance matrix will be retained.',
-        'exclude_ids': 'If `True`, returns the filtered distance matrix '
-                       'containing the set of samples which occur in the '
-                       'distance matrix but not in the metadata (or the '
-                       'filtered metadata, if invoked in conjunction with '
-                       '`where`).'
+        'exclude_ids': 'If `True`, the samples selected by `metadata` or '
+                       '`where` parameters will be excluded from the filtered '
+                       'distance matrix instead of being retained.'
     },
     output_descriptions={
         'filtered_distance_matrix': 'Distance matrix filtered to include '

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -208,7 +208,8 @@ plugin.methods.register_function(
     },
     parameters={
         'metadata': Metadata,
-        'where': Str
+        'where': Str,
+        'exclude_ids': Bool
     },
     outputs=[
         ('filtered_distance_matrix', DistanceMatrix)
@@ -216,8 +217,10 @@ plugin.methods.register_function(
     name="Filter samples from a distance matrix.",
     description="Filter samples from a distance matrix, retaining only the "
                 "samples matching search criteria specified by "
-                "`metadata` and `where` parameters. See the filtering "
-                "tutorial on https://docs.qiime2.org for additional details.",
+                "`metadata` and `where` parameters (or retaining only the "
+                "samples not matching that criteria, if `exclude_ids` is "
+                "True). See the filtering tutorial on "
+                "https://docs.qiime2.org for additional details.",
     input_descriptions={
         'distance_matrix': 'Distance matrix to filter by sample.'
     },
@@ -227,7 +230,12 @@ plugin.methods.register_function(
         'where': 'SQLite WHERE clause specifying sample metadata criteria '
                  'that must be met to be included in the filtered distance '
                  'matrix. If not provided, all samples in `metadata` that are '
-                 'also in the input distance matrix will be retained.'
+                 'also in the input distance matrix will be retained.',
+        'exclude_ids': 'If `True`, returns the filtered distance matrix '
+                       'containing the set of samples which occur in the '
+                       'feature table but not in the metadata (or the '
+                       'filtered metadata, if invoked in conjunction with '
+                       '`where`).'
     },
     output_descriptions={
         'filtered_distance_matrix': 'Distance matrix filtered to include '

--- a/q2_diversity/tests/test_filter.py
+++ b/q2_diversity/tests/test_filter.py
@@ -190,11 +190,10 @@ class TestFilterDistanceMatrix(unittest.TestCase):
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
 
-        with self.assertRaisesRegex(ValueError,
-                                    "Selection.*IDs.*failed.*query.*"):
-            filter_distance_matrix(dm, metadata,
-                                   where="SampleType='toe",
-                                   exclude_ids=True)
+        filtered = filter_distance_matrix(dm, metadata,
+                                          where="SampleType='toe'",
+                                          exclude_ids=True)
+        self.assertEqual(self._sorted(filtered), dm)
 
         # where filter one -> exclude one
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],

--- a/q2_diversity/tests/test_filter.py
+++ b/q2_diversity/tests/test_filter.py
@@ -135,27 +135,28 @@ class TestFilterDistanceMatrix(unittest.TestCase):
         expected = skbio.DistanceMatrix([[0]], ['S3'])
         self.assertEqual(filtered, expected)
 
-    def test_with_exclude_ids(self):
-        # set up
-        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
-                                  ['S1', 'S2', 'S3'])
-
-        # metadata filter nothing -> exclude nothing
+    def test_with_exclude_ids_filter_nothing(self):
         df = pd.DataFrame({'Subject': ['subject-1'],
                            'SampleType': ['tongue']},
                           index=['S2000'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         filtered = filter_distance_matrix(dm, metadata,
                                           where=None,
                                           exclude_ids=True)
         self.assertEqual(self._sorted(filtered), dm)
 
-        # metadata filter one -> exclude one
+    def test_with_exclude_ids_filter_one(self):
         df = pd.DataFrame({'Subject': ['subject-1'],
                            'SampleType': ['tongue']},
                           index=['S2'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         filtered = filter_distance_matrix(dm, metadata,
                                           where=None,
@@ -163,11 +164,14 @@ class TestFilterDistanceMatrix(unittest.TestCase):
         expected = skbio.DistanceMatrix([[0, 2], [2, 0]], ['S1', 'S3'])
         self.assertEqual(self._sorted(filtered), expected)
 
-        # metadata filter two -> exclude two
+    def test_with_exclude_ids_filter_two(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1'],
                            'SampleType': ['gut', 'tongue']},
                           index=['S1', 'S2'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         filtered = filter_distance_matrix(dm, metadata,
                                           where=None,
@@ -175,31 +179,40 @@ class TestFilterDistanceMatrix(unittest.TestCase):
         expected = skbio.DistanceMatrix([[0]], ['S3'])
         self.assertEqual(self._sorted(filtered), expected)
 
-        # metadata filter all -> exclude all
+    def test_with_exclude_ids_filter_all(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         with self.assertRaisesRegex(ValueError, "All samples.*filtered"):
             filter_distance_matrix(dm, metadata, where=None, exclude_ids=True)
 
-        # where filter nothing -> exclude nothing
+    def test_with_exclude_ids_where_filter_nothing(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         filtered = filter_distance_matrix(dm, metadata,
                                           where="SampleType='toe'",
                                           exclude_ids=True)
         self.assertEqual(self._sorted(filtered), dm)
 
-        # where filter one -> exclude one
+    def test_with_exclude_ids_where_filter_one(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
 
         filtered = filter_distance_matrix(dm, metadata,
                                           where="SampleType='tongue'",
@@ -208,11 +221,15 @@ class TestFilterDistanceMatrix(unittest.TestCase):
                                         ['S1', 'S3'])
         self.assertEqual(self._sorted(filtered), expected)
 
-        # where filter two -> exclude two
+    def test_with_exclude_ids_where_filter_two(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['elbow', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
         where = "SampleType='tongue' OR SampleType='gut'"
 
         filtered = filter_distance_matrix(dm, metadata,
@@ -221,11 +238,15 @@ class TestFilterDistanceMatrix(unittest.TestCase):
         expected = skbio.DistanceMatrix([[0]], ['S1'])
         self.assertEqual(filtered, expected)
 
-        # where filter all -> exclude all
+    def test_with_exclude_ids_where_filter_all(self):
         df = pd.DataFrame({'Subject': ['subject-1', 'subject-1', 'subject-2'],
                            'SampleType': ['gut', 'tongue', 'gut']},
                           index=['S1', 'S2', 'S3'])
         metadata = qiime2.Metadata(df)
+
+        dm = skbio.DistanceMatrix([[0, 1, 2], [1, 0, 3], [2, 3, 0]],
+                                  ['S1', 'S2', 'S3'])
+
         where = "SampleType='tongue' OR SampleType='gut'"
 
         with self.assertRaisesRegex(ValueError, "All samples.*filtered"):


### PR DESCRIPTION
This feature replicates the `exclude_ids` feature [recently implemented in q2-feature-table](https://github.com/qiime2/q2-feature-table/pull/112).  When `exclude_ids=True`, the samples with ids matching those satisfying the `metadata` (or optionally the `where` clause on the `metadata`) are excluded from rather than included in the DistanceMatrix that is returned by `_filter`.  `False` by default.