### PR TITLE
ENH: core-metrics upgrades

### DIFF
--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -11,7 +11,7 @@ from ._alpha import (alpha, alpha_phylogenetic, alpha_group_significance,
 from ._beta import (beta, beta_phylogenetic, bioenv, beta_group_significance,
                     beta_correlation, beta_rarefaction)
 from ._ordination import pcoa
-from ._core_metrics import core_metrics
+from ._core_metrics import core_metrics_phylogenetic, core_metrics
 from ._filter import filter_distance_matrix
 from ._version import get_versions
 
@@ -21,5 +21,6 @@ del get_versions
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic', 'pcoa',
            'alpha_group_significance', 'bioenv', 'beta_group_significance',
-           'alpha_correlation', 'core_metrics', 'filter_distance_matrix',
-           'beta_correlation', 'alpha_rarefaction', 'beta_rarefaction']
+           'alpha_correlation', 'core_metrics_phylogenetic', 'core_metrics',
+           'filter_distance_matrix', 'beta_correlation', 'alpha_rarefaction',
+           'beta_rarefaction']

--- a/q2_diversity/_core_metrics.py
+++ b/q2_diversity/_core_metrics.py
@@ -15,52 +15,83 @@ from q2_diversity import (alpha, alpha_phylogenetic, beta, beta_phylogenetic,
 from q2_feature_table import rarefy
 
 
+_core_phylogenetic_output = (pd.Series,
+                             pd.Series,
+                             pd.Series,
+                             pd.Series,
+                             skbio.DistanceMatrix,
+                             skbio.DistanceMatrix,
+                             skbio.DistanceMatrix,
+                             skbio.DistanceMatrix,
+                             skbio.OrdinationResults,
+                             skbio.OrdinationResults,
+                             skbio.OrdinationResults,
+                             skbio.OrdinationResults)
+
 _core_output = (pd.Series,
                 pd.Series,
                 pd.Series,
-                pd.Series,
                 skbio.DistanceMatrix,
                 skbio.DistanceMatrix,
-                skbio.DistanceMatrix,
-                skbio.DistanceMatrix,
-                skbio.OrdinationResults,
-                skbio.OrdinationResults,
                 skbio.OrdinationResults,
                 skbio.OrdinationResults)
 
 
-def core_metrics(table: biom.Table, phylogeny: skbio.TreeNode,
-                 sampling_depth: int, n_jobs: int=1) -> _core_output:
+def _core_metrics(table, sampling_depth, n_jobs, phylogeny=None):
     rarefied_table = rarefy(table=table, sampling_depth=sampling_depth)
 
-    faith_pd_vector = alpha_phylogenetic(
-        table=rarefied_table, phylogeny=phylogeny, metric='faith_pd')
+    # Non-Phylogenetic Metrics
     observed_otus_vector = alpha(table=rarefied_table, metric='observed_otus')
     shannon_vector = alpha(table=rarefied_table, metric='shannon')
     evenness_vector = alpha(table=rarefied_table, metric='pielou_e')
 
-    unweighted_unifrac_distance_matrix = beta_phylogenetic(
-        table=rarefied_table, phylogeny=phylogeny, metric='unweighted_unifrac',
-        n_jobs=n_jobs)
-    weighted_unifrac_distance_matrix = beta_phylogenetic(
-        table=rarefied_table, phylogeny=phylogeny, metric='weighted_unifrac')
     jaccard_distance_matrix = beta(table=rarefied_table, metric='jaccard',
                                    n_jobs=n_jobs)
     bray_curtis_distance_matrix = beta(
         table=rarefied_table, metric='braycurtis', n_jobs=n_jobs)
 
-    unweighted_unifrac_pcoa_results = pcoa(
-        distance_matrix=unweighted_unifrac_distance_matrix)
-    weighted_unifrac_pcoa_results = pcoa(
-        distance_matrix=weighted_unifrac_distance_matrix)
     jaccard_pcoa_results = pcoa(distance_matrix=jaccard_distance_matrix)
     bray_curtis_pcoa_results = pcoa(
         distance_matrix=bray_curtis_distance_matrix)
 
-    return (
-        faith_pd_vector, observed_otus_vector, shannon_vector, evenness_vector,
-        unweighted_unifrac_distance_matrix, weighted_unifrac_distance_matrix,
-        jaccard_distance_matrix, bray_curtis_distance_matrix,
-        unweighted_unifrac_pcoa_results, weighted_unifrac_pcoa_results,
-        jaccard_pcoa_results, bray_curtis_pcoa_results
-    )
+    # Phylogenetic Metrics
+    if phylogeny is not None:
+        faith_pd_vector = alpha_phylogenetic(
+            table=rarefied_table, phylogeny=phylogeny, metric='faith_pd')
+
+        unweighted_unifrac_distance_matrix = beta_phylogenetic(
+            table=rarefied_table, phylogeny=phylogeny,
+            metric='unweighted_unifrac', n_jobs=n_jobs)
+        weighted_unifrac_distance_matrix = beta_phylogenetic(
+            table=rarefied_table, phylogeny=phylogeny,
+            metric='weighted_unifrac')
+
+        unweighted_unifrac_pcoa_results = pcoa(
+            distance_matrix=unweighted_unifrac_distance_matrix)
+        weighted_unifrac_pcoa_results = pcoa(
+            distance_matrix=weighted_unifrac_distance_matrix)
+
+        metrics = (faith_pd_vector, observed_otus_vector, shannon_vector,
+                   evenness_vector, unweighted_unifrac_distance_matrix,
+                   weighted_unifrac_distance_matrix, jaccard_distance_matrix,
+                   bray_curtis_distance_matrix,
+                   unweighted_unifrac_pcoa_results,
+                   weighted_unifrac_pcoa_results, jaccard_pcoa_results,
+                   bray_curtis_pcoa_results)
+    else:
+        metrics = (observed_otus_vector, shannon_vector, evenness_vector,
+                   jaccard_distance_matrix, bray_curtis_distance_matrix,
+                   jaccard_pcoa_results, bray_curtis_pcoa_results)
+
+    return metrics
+
+
+def core_metrics_phylogenetic(table: biom.Table, phylogeny: skbio.TreeNode,
+                              sampling_depth: int,
+                              n_jobs: int=1) -> _core_phylogenetic_output:
+    return _core_metrics(table, sampling_depth, n_jobs, phylogeny)
+
+
+def core_metrics(table: biom.Table, sampling_depth: int,
+                 n_jobs: int=1) -> _core_output:
+    return _core_metrics(table, sampling_depth, n_jobs)

--- a/q2_diversity/_core_metrics.py
+++ b/q2_diversity/_core_metrics.py
@@ -15,7 +15,8 @@ from q2_diversity import (alpha, alpha_phylogenetic, beta, beta_phylogenetic,
 from q2_feature_table import rarefy
 
 
-_core_phylogenetic_output = (pd.Series,
+_core_phylogenetic_output = (biom.Table,
+                             pd.Series,
                              pd.Series,
                              pd.Series,
                              pd.Series,
@@ -28,7 +29,8 @@ _core_phylogenetic_output = (pd.Series,
                              skbio.OrdinationResults,
                              skbio.OrdinationResults)
 
-_core_output = (pd.Series,
+_core_output = (biom.Table,
+                pd.Series,
                 pd.Series,
                 pd.Series,
                 skbio.DistanceMatrix,
@@ -71,17 +73,19 @@ def _core_metrics(table, sampling_depth, n_jobs, phylogeny=None):
         weighted_unifrac_pcoa_results = pcoa(
             distance_matrix=weighted_unifrac_distance_matrix)
 
-        metrics = (faith_pd_vector, observed_otus_vector, shannon_vector,
-                   evenness_vector, unweighted_unifrac_distance_matrix,
+        metrics = (rarefied_table, faith_pd_vector, observed_otus_vector,
+                   shannon_vector, evenness_vector,
+                   unweighted_unifrac_distance_matrix,
                    weighted_unifrac_distance_matrix, jaccard_distance_matrix,
                    bray_curtis_distance_matrix,
                    unweighted_unifrac_pcoa_results,
                    weighted_unifrac_pcoa_results, jaccard_pcoa_results,
                    bray_curtis_pcoa_results)
     else:
-        metrics = (observed_otus_vector, shannon_vector, evenness_vector,
-                   jaccard_distance_matrix, bray_curtis_distance_matrix,
-                   jaccard_pcoa_results, bray_curtis_pcoa_results)
+        metrics = (rarefied_table, observed_otus_vector, shannon_vector,
+                   evenness_vector, jaccard_distance_matrix,
+                   bray_curtis_distance_matrix, jaccard_pcoa_results,
+                   bray_curtis_pcoa_results)
 
     return metrics
 

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -161,6 +161,7 @@ plugin.methods.register_function(
         'n_jobs': Int
     },
     outputs=[
+        ('rarefied_table', FeatureTable[Frequency]),
         ('faith_pd_vector', SampleData[AlphaDiversity]),
         ('observed_otus_vector', SampleData[AlphaDiversity]),
         ('shannon_vector', SampleData[AlphaDiversity]),
@@ -190,6 +191,7 @@ plugin.methods.register_function(
                   'unifrac] - %s' % sklearn_n_jobs_description
     },
     output_descriptions={
+        'rarefied_table': 'The resulting rarefied feature table.',
         'faith_pd_vector': 'Vector of Faith PD values by sample.',
         'observed_otus_vector': 'Vector of Observed OTUs values by sample.',
         'shannon_vector': 'Vector of Shannon diversity values by sample.',
@@ -230,6 +232,7 @@ plugin.methods.register_function(
         'n_jobs': Int
     },
     outputs=[
+        ('rarefied_table', FeatureTable[Frequency]),
         ('observed_otus_vector', SampleData[AlphaDiversity]),
         ('shannon_vector', SampleData[AlphaDiversity]),
         ('evenness_vector', SampleData[AlphaDiversity]),
@@ -248,6 +251,7 @@ plugin.methods.register_function(
         'n_jobs': '[beta methods only] - %s' % sklearn_n_jobs_description
     },
     output_descriptions={
+        'rarefied_table': 'The resulting rarefied feature table.',
         'observed_otus_vector': 'Vector of Observed OTUs values by sample.',
         'shannon_vector': 'Vector of Shannon diversity values by sample.',
         'evenness_vector': 'Vector of Pielou\'s evenness values by sample.',

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -151,7 +151,7 @@ plugin.methods.register_function(
 )
 
 plugin.methods.register_function(
-    function=q2_diversity.core_metrics,
+    function=q2_diversity.core_metrics_phylogenetic,
     inputs={
         'table': FeatureTable[Frequency],
         'phylogeny': Phylogeny[Rooted]
@@ -175,13 +175,13 @@ plugin.methods.register_function(
         ('bray_curtis_pcoa_results', PCoAResults)
     ],
     input_descriptions={
-        'table': ('The feature table containing the samples over which '
-                  'diversity metrics should be computed.'),
-        'phylogeny': ('Phylogenetic tree containing tip identifiers that '
-                      'correspond to the feature identifiers in the table. '
-                      'This tree can contain tip ids that are not present in '
-                      'the table, but all feature ids in the table must be '
-                      'present in this tree.')
+        'table': 'The feature table containing the samples over which '
+                 'diversity metrics should be computed.',
+        'phylogeny': 'Phylogenetic tree containing tip identifiers that '
+                     'correspond to the feature identifiers in the table. '
+                     'This tree can contain tip ids that are not present in '
+                     'the table, but all feature ids in the table must be '
+                     'present in this tree.'
     },
     parameter_descriptions={
         'sampling_depth': 'The total frequency that each sample should be '
@@ -203,20 +203,66 @@ plugin.methods.register_function(
         'bray_curtis_distance_matrix':
             'Matrix of Bray-Curtis distances between pairs of samples.',
         'unweighted_unifrac_pcoa_results':
-            ('PCoA matrix computed from unweighted UniFrac distances between '
-             'samples.'),
+            'PCoA matrix computed from unweighted UniFrac distances between '
+            'samples.',
         'weighted_unifrac_pcoa_results':
-            ('PCoA matrix computed from weighted UniFrac distances between '
-             'samples.'),
+            'PCoA matrix computed from weighted UniFrac distances between '
+            'samples.',
         'jaccard_pcoa_results':
-            ('PCoA matrix computed from Jaccard distances between '
-             'samples.'),
+            'PCoA matrix computed from Jaccard distances between '
+            'samples.',
         'bray_curtis_pcoa_results':
-            ('PCoA matrix computed from Bray-Curtis distances between '
-             'samples.'),
+            'PCoA matrix computed from Bray-Curtis distances between '
+            'samples.',
     },
-    name='Core diversity metrics',
-    description="Applies a collection of diversity metrics to a feature table."
+    name='Core diversity metrics (phylogenetic and non-phylogenetic)',
+    description="Applies a collection of diversity metrics (both "
+                "phylogenetic and non-phylogenetic) to a feature table.",
+)
+
+plugin.methods.register_function(
+    function=q2_diversity.core_metrics,
+    inputs={
+        'table': FeatureTable[Frequency],
+    },
+    parameters={
+        'sampling_depth': Int,
+        'n_jobs': Int
+    },
+    outputs=[
+        ('observed_otus_vector', SampleData[AlphaDiversity]),
+        ('shannon_vector', SampleData[AlphaDiversity]),
+        ('evenness_vector', SampleData[AlphaDiversity]),
+        ('jaccard_distance_matrix', DistanceMatrix),
+        ('bray_curtis_distance_matrix', DistanceMatrix),
+        ('jaccard_pcoa_results', PCoAResults),
+        ('bray_curtis_pcoa_results', PCoAResults)
+    ],
+    input_descriptions={
+        'table': 'The feature table containing the samples over which '
+                 'diversity metrics should be computed.',
+    },
+    parameter_descriptions={
+        'sampling_depth': 'The total frequency that each sample should be '
+                          'rarefied to prior to computing diversity metrics.',
+        'n_jobs': '[beta methods only] - %s' % sklearn_n_jobs_description
+    },
+    output_descriptions={
+        'observed_otus_vector': 'Vector of Observed OTUs values by sample.',
+        'shannon_vector': 'Vector of Shannon diversity values by sample.',
+        'evenness_vector': 'Vector of Pielou\'s evenness values by sample.',
+        'jaccard_distance_matrix':
+            'Matrix of Jaccard distances between pairs of samples.',
+        'bray_curtis_distance_matrix':
+            'Matrix of Bray-Curtis distances between pairs of samples.',
+        'jaccard_pcoa_results':
+            'PCoA matrix computed from Jaccard distances between samples.',
+        'bray_curtis_pcoa_results':
+            'PCoA matrix computed from Bray-Curtis distances between samples.',
+    },
+    name='Core diversity metrics (non-phylogenetic)',
+    description=("Applies a collection of diversity metrics "
+                 "(non-phylogenetic) to a feature table."),
 )
 
 plugin.methods.register_function(

--- a/q2_diversity/tests/test_core_metrics.py
+++ b/q2_diversity/tests/test_core_metrics.py
@@ -15,18 +15,17 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
 
-from q2_diversity import core_metrics
+from q2_diversity import core_metrics_phylogenetic, core_metrics
 
 
 class CoreMetricsTests(unittest.TestCase):
-
-    def test_core_metrics(self):
+    def test_core_metrics_phylogenetic(self):
         table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
                            ['O1', 'O2'],
                            ['S1', 'S2', 'S3'])
         tree = skbio.TreeNode.read(io.StringIO(
             '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
-        results = core_metrics(table, tree, 13)
+        results = core_metrics_phylogenetic(table, tree, 13)
 
         self.assertEqual(len(results), 12)
 
@@ -34,16 +33,27 @@ class CoreMetricsTests(unittest.TestCase):
                              name='observed_otus')
         pdt.assert_series_equal(results[1], expected)
 
-    def test_core_metrics_rarefy_drops_sample(self):
+    def test_core_metrics_phylogenetic_rarefy_drops_sample(self):
         table = biom.Table(np.array([[0, 11, 11], [12, 11, 11]]),
                            ['O1', 'O2'],
                            ['S1', 'S2', 'S3'])
         tree = skbio.TreeNode.read(io.StringIO(
             '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
-        results = core_metrics(table, tree, 13)
+        results = core_metrics_phylogenetic(table, tree, 13)
 
         self.assertEqual(len(results), 12)
 
         expected = pd.Series({'S2': 2, 'S3': 2},
                              name='observed_otus')
         pdt.assert_series_equal(results[1], expected)
+
+    def test_core_metrics(self):
+        table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
+                           ['O1', 'O2'],
+                           ['S1', 'S2', 'S3'])
+        results = core_metrics(table, 13)
+
+        self.assertEqual(len(results), 7)
+
+        expected = pd.Series({'S1': 1, 'S2': 2, 'S3': 2}, name='observed_otus')
+        pdt.assert_series_equal(results[0], expected)

--- a/q2_diversity/tests/test_core_metrics.py
+++ b/q2_diversity/tests/test_core_metrics.py
@@ -27,11 +27,11 @@ class CoreMetricsTests(unittest.TestCase):
             '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
         results = core_metrics_phylogenetic(table, tree, 13)
 
-        self.assertEqual(len(results), 12)
+        self.assertEqual(len(results), 13)
 
         expected = pd.Series({'S1': 1, 'S2': 2, 'S3': 2},
                              name='observed_otus')
-        pdt.assert_series_equal(results[1], expected)
+        pdt.assert_series_equal(results[2], expected)
 
     def test_core_metrics_phylogenetic_rarefy_drops_sample(self):
         table = biom.Table(np.array([[0, 11, 11], [12, 11, 11]]),
@@ -41,11 +41,11 @@ class CoreMetricsTests(unittest.TestCase):
             '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
         results = core_metrics_phylogenetic(table, tree, 13)
 
-        self.assertEqual(len(results), 12)
+        self.assertEqual(len(results), 13)
 
         expected = pd.Series({'S2': 2, 'S3': 2},
                              name='observed_otus')
-        pdt.assert_series_equal(results[1], expected)
+        pdt.assert_series_equal(results[2], expected)
 
     def test_core_metrics(self):
         table = biom.Table(np.array([[0, 11, 11], [13, 11, 11]]),
@@ -53,7 +53,7 @@ class CoreMetricsTests(unittest.TestCase):
                            ['S1', 'S2', 'S3'])
         results = core_metrics(table, 13)
 
-        self.assertEqual(len(results), 7)
+        self.assertEqual(len(results), 8)
 
         expected = pd.Series({'S1': 1, 'S2': 2, 'S3': 2}, name='observed_otus')
-        pdt.assert_series_equal(results[0], expected)
+        pdt.assert_series_equal(results[1], expected)


### PR DESCRIPTION
Note to reviewer, please "rebase and merge," I would like to preserve the two logical commits represented in this PR.

---

This PR adds support for running non-phylogenetic `core-metrics`. Note, this changes the existing behavior of `core-metrics`, now removing the `tree` input. 

Fixes #112 

This PR also adds support for returning the rarefied table in both `core-metrics*` methods.

Fixes #126 