### PR TITLE
BUG: ignore empty metadata columns

### DIFF
--- a/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
@@ -9,6 +9,16 @@
 <div class='row'>
   <div class='col-lg-12' id='main'>
     <h1>Alpha rarefaction</h1>
+
+    {% if empty_columns %}
+    <div class="row">
+      <p class="alert alert-warning col-md-12">
+        The following metadata categories have been omitted because they did not contain any values:
+        <strong>{{ empty_columns|join(', ') }}</strong>
+      </p>
+    </div>
+    {% endif %}
+
     <div class='controls row'>
       <div class='col-lg-2 form-group downloadCSV'>
         <label>&nbsp;</label>

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -65,6 +65,31 @@ class AlphaRarefactionTests(unittest.TestCase):
             metric_fp = os.path.join(output_dir, 'shannon-pet.jsonp')
             self.assertTrue('summer' not in open(metric_fp).read())
 
+    def test_alpha_rarefaction_with_empty_column_in_metadata(self):
+        t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
+                       ['O1', 'O2'],
+                       ['S1', 'S2', 'S3'])
+        md = qiime2.Metadata(
+            pd.DataFrame({'pet': ['russ', 'milo', 'peanut', 'summer'],
+                          'foo': [np.nan, np.nan, np.nan, 'bar']},
+                         index=['S1', 'S2', 'S3', 'S4']))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
+
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            with open(index_fp, 'r') as fh:
+                contents = fh.read()
+
+            self.assertTrue('observed_otus' in contents)
+            self.assertTrue('shannon' in contents)
+            self.assertTrue('did not contain any values:' in contents)
+
+            metric_fp = os.path.join(output_dir, 'shannon-pet.jsonp')
+            self.assertTrue('summer' not in open(metric_fp).read())
+            self.assertFalse(
+                os.path.exists(os.path.join(output_dir, 'shannon-foo.jsonp')))
+
     def test_alpha_rarefaction_with_phylogeny(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],
@@ -452,3 +477,7 @@ class BetaRarefactionJSONPTests(unittest.TestCase):
             self.assertTrue('data' in jsonp_content)
             self.assertTrue('sample-id' in jsonp_content)
             self.assertTrue('shannon' in jsonp_content)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Empty columns are ignored and a warning is displayed in the visualization listing the empty columns.

Fixes #141.

Example:

![image](https://user-images.githubusercontent.com/1847232/30945439-2bf553fa-a3b3-11e7-9a5e-ea5a03b67563.png)
