### PR TITLE
BUG: Handle metadata cols with spaces in the label (alpha-rare)

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -352,7 +352,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
                 c_df = _compute_summary(reindexed_df, column, counts=counts)
                 jsonp_filename = "%s-%s.jsonp" % (metric_name, column_name)
                 _alpha_rarefaction_jsonp(output_dir, jsonp_filename,
-                                         metric_name, c_df, column_name)
+                                         metric_name, c_df, column)
                 filenames.append(jsonp_filename)
 
         with open(os.path.join(output_dir, filename), 'w') as fh:
@@ -365,7 +365,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
     index = os.path.join(TEMPLATES, 'alpha_rarefaction_assets', 'index.html')
     q2templates.render(index, output_dir,
                        context={'metrics': list(metrics),
-                                'filenames': filenames,
+                                'filenames': [quote(f) for f in filenames],
                                 'columns': list(columns),
                                 'filtered_columns': sorted(filtered_columns)})
 

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/src/init.js
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/src/init.js
@@ -16,5 +16,7 @@ export default function init() {
   addMetricPicker(controlsRow, metrics, metric);
   if (columns.length > 0) {
     addColumnPicker(controlsRow, columns, column);
+  } else {
+    controlsRow.selectAll('.columnPicker').remove();
   }
 }

--- a/q2_diversity/tests/test_alpha.py
+++ b/q2_diversity/tests/test_alpha.py
@@ -122,10 +122,12 @@ class AlphaCorrelationTests(unittest.TestCase):
             jsonp_fp = os.path.join(output_dir, 'column-value.jsonp')
             self.assertTrue(os.path.exists(jsonp_fp))
 
-            self.assertTrue('Spearman' in open(jsonp_fp).read())
-            self.assertTrue('"sampleSize": 3' in open(jsonp_fp).read())
-            self.assertTrue('"data":' in open(jsonp_fp).read())
-            self.assertFalse('filtered' in open(jsonp_fp).read())
+            with open(jsonp_fp) as jsonp_fh:
+                jsonp_content = jsonp_fh.read()
+            self.assertTrue('Spearman' in jsonp_content)
+            self.assertTrue('"sampleSize": 3' in jsonp_content)
+            self.assertTrue('"data":' in jsonp_content)
+            self.assertFalse('filtered' in jsonp_content)
 
     def test_pearson(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -141,10 +143,12 @@ class AlphaCorrelationTests(unittest.TestCase):
             jsonp_fp = os.path.join(output_dir, 'column-value.jsonp')
             self.assertTrue(os.path.exists(jsonp_fp))
 
-            self.assertTrue('Pearson' in open(jsonp_fp).read())
-            self.assertTrue('"sampleSize": 3' in open(jsonp_fp).read())
-            self.assertTrue('"data":' in open(jsonp_fp).read())
-            self.assertFalse('filtered' in open(jsonp_fp).read())
+            with open(jsonp_fp) as jsonp_fh:
+                jsonp_content = jsonp_fh.read()
+            self.assertTrue('Pearson' in jsonp_content)
+            self.assertTrue('"sampleSize": 3' in jsonp_content)
+            self.assertTrue('"data":' in jsonp_content)
+            self.assertFalse('filtered' in jsonp_content)
 
     def test_bad_method(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -175,9 +179,10 @@ class AlphaCorrelationTests(unittest.TestCase):
             self.assertFalse(os.path.exists(
                              os.path.join(output_dir,
                                           'column-col2.jsonp')))
-            self.assertTrue(
-                "contain numeric data" in open(index_fp).read())
-            self.assertTrue('<strong>col2' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('contain numeric data' in index_content)
+            self.assertTrue('<strong>col2' in index_content)
 
     def test_nan_metadata(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -192,9 +197,10 @@ class AlphaCorrelationTests(unittest.TestCase):
             self.assertTrue(os.path.exists(index_fp))
             jsonp_fp = os.path.join(output_dir, 'column-value.jsonp')
             self.assertTrue(os.path.exists(jsonp_fp))
-
-            self.assertTrue('"filtered": 2' in open(jsonp_fp).read())
-            self.assertTrue('"initial": 3' in open(jsonp_fp).read())
+            with open(jsonp_fp) as jsonp_fh:
+                jsonp_content = jsonp_fh.read()
+            self.assertTrue('"filtered": 2' in jsonp_content)
+            self.assertTrue('"initial": 3' in jsonp_content)
 
     def test_extra_metadata(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -211,7 +217,8 @@ class AlphaCorrelationTests(unittest.TestCase):
             jsonp_fp = os.path.join(output_dir, 'column-value.jsonp')
             self.assertTrue(os.path.exists(jsonp_fp))
 
-            self.assertTrue('"sampleSize": 3' in open(jsonp_fp).read())
+            with open(jsonp_fp) as jsonp_fh:
+                self.assertTrue('"sampleSize": 3' in jsonp_fh.read())
 
     def test_extra_alpha_div(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0, 8.0], name='alpha-div',
@@ -258,10 +265,10 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
             self.assertTrue(os.path.exists(
                             os.path.join(output_dir,
                                          'column-a%20or%20b.jsonp')))
-            self.assertTrue('Kruskal-Wallis (all groups)'
-                            in open(index_fp).read())
-            self.assertTrue('Kruskal-Wallis (pairwise)'
-                            in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('Kruskal-Wallis (all groups)' in index_content)
+            self.assertTrue('Kruskal-Wallis (pairwise)' in index_content)
 
     def test_alpha_group_significance_some_numeric(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -282,9 +289,10 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
             self.assertFalse(os.path.exists(
                              os.path.join(output_dir,
                                           'column-bad.jsonp')))
-            self.assertTrue(
-                "contain categorical data:" in open(index_fp).read())
-            self.assertTrue('<strong>bad' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('contain categorical data:' in index_content)
+            self.assertTrue('<strong>bad' in index_content)
 
     def test_alpha_group_significance_one_group_all_unique_values(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -305,8 +313,10 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
             self.assertFalse(os.path.exists(
                              os.path.join(output_dir,
                                           'column-bad.jsonp')))
-            self.assertTrue('number of samples' in open(index_fp).read())
-            self.assertTrue('<strong>bad' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('number of samples' in index_content)
+            self.assertTrue('<strong>bad' in index_content)
 
     def test_alpha_group_significance_one_group_single_value(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -327,8 +337,10 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
             self.assertFalse(os.path.exists(
                              os.path.join(output_dir,
                                           'column-bad.jsonp')))
-            self.assertTrue('single group' in open(index_fp).read())
-            self.assertTrue('<strong>bad' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('single group' in index_content)
+            self.assertTrue('<strong>bad' in index_content)
 
     def test_alpha_group_significance_KW_value_error(self):
         alpha_div = pd.Series([2.0, 2.0, 3.0, 2.0], name='alpha-div',
@@ -346,9 +358,11 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
             self.assertTrue(os.path.exists(
                             os.path.join(output_dir,
                                          'column-x.jsonp')))
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
             self.assertTrue('pairwise group comparisons have been omitted'
-                            in open(index_fp).read())
-            self.assertTrue('x:c (n=1) vs x:a (n=1)' in open(index_fp).read())
+                            in index_content)
+            self.assertTrue('x:c (n=1) vs x:a (n=1)' in index_content)
 
     def test_alpha_group_significance_numeric_only(self):
         alpha_div = pd.Series([2.0, 4.0, 6.0], name='alpha-div',
@@ -376,7 +390,8 @@ class AlphaGroupSignificanceTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as output_dir:
             alpha_group_significance(output_dir, alpha_div, md)
             index_fp = os.path.join(output_dir, 'index.html')
-            self.assertTrue("\'" in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                self.assertTrue("\'" in index_fh.read())
 
 
 if __name__ == '__main__':

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -32,8 +32,10 @@ class AlphaRarefactionTests(unittest.TestCase):
             alpha_rarefaction(output_dir, t, max_depth=200)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
 
     def test_alpha_rarefaction_with_metadata(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
@@ -46,8 +48,10 @@ class AlphaRarefactionTests(unittest.TestCase):
             alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
 
     def test_alpha_rarefaction_with_superset_metadata(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
@@ -60,10 +64,13 @@ class AlphaRarefactionTests(unittest.TestCase):
             alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
             metric_fp = os.path.join(output_dir, 'shannon-pet.jsonp')
-            self.assertTrue('summer' not in open(metric_fp).read())
+            with open(metric_fp) as metric_fh:
+                self.assertTrue('summer' not in metric_fh.read())
 
     def test_alpha_rarefaction_with_filtered_metadata_columns(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
@@ -82,7 +89,6 @@ class AlphaRarefactionTests(unittest.TestCase):
             self.assertTrue(os.path.exists(index_fp))
             with open(index_fp, 'r') as fh:
                 contents = fh.read()
-
             self.assertTrue('observed_otus' in contents)
             self.assertTrue('shannon' in contents)
             self.assertTrue('didn\'t contain categorical data' in contents)
@@ -90,7 +96,8 @@ class AlphaRarefactionTests(unittest.TestCase):
             self.assertTrue('<strong>bar, foo' in contents)
 
             metric_fp = os.path.join(output_dir, 'shannon-pet.jsonp')
-            self.assertTrue('summer' not in open(metric_fp).read())
+            with open(metric_fp) as metric_fh:
+                self.assertTrue('summer' not in metric_fh.read())
             self.assertFalse(
                 os.path.exists(os.path.join(output_dir, 'shannon-foo.jsonp')))
             self.assertFalse(
@@ -107,9 +114,11 @@ class AlphaRarefactionTests(unittest.TestCase):
             alpha_rarefaction(output_dir, t, max_depth=200, phylogeny=p)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
-            self.assertTrue('faith_pd' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
+            self.assertTrue('faith_pd' in index_content)
 
     def test_alpha_rarefaction_with_phylogeny_and_metadata(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
@@ -126,9 +135,11 @@ class AlphaRarefactionTests(unittest.TestCase):
                               metadata=md)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
-            self.assertTrue('faith_pd' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
+            self.assertTrue('faith_pd' in index_content)
 
     def test_invalid_invocations(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
@@ -184,9 +195,11 @@ class AlphaRarefactionTests(unittest.TestCase):
                               max_depth=200)
             index_fp = os.path.join(output_dir, 'index.html')
             self.assertTrue(os.path.exists(index_fp))
-            self.assertTrue('observed_otus' in open(index_fp).read())
-            self.assertTrue('shannon' in open(index_fp).read())
-            self.assertTrue('pielou_e' in open(index_fp).read())
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
+            self.assertTrue('pielou_e' in index_content)
 
 
 class ComputeRarefactionDataTests(unittest.TestCase):
@@ -494,7 +507,8 @@ class AlphaRarefactionJSONPTests(unittest.TestCase):
 
             jsonp_fp = os.path.join(output_dir, 'peanut.jsonp')
             self.assertTrue(os.path.exists(jsonp_fp))
-            jsonp_content = open(jsonp_fp).read()
+            with open(jsonp_fp) as jsonp_fh:
+                jsonp_content = jsonp_fh.read()
             self.assertTrue('load_data' in jsonp_content)
             self.assertTrue('columns' in jsonp_content)
             self.assertTrue('index' in jsonp_content)

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -201,6 +201,24 @@ class AlphaRarefactionTests(unittest.TestCase):
             self.assertTrue('shannon' in index_content)
             self.assertTrue('pielou_e' in index_content)
 
+    def test_alpha_rarefaction_with_metadata_column_with_spaces(self):
+        t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
+                       ['O1', 'O2'],
+                       ['S1', 'S2', 'S3'])
+        md = qiime2.Metadata(
+            pd.DataFrame({'pet name': ['russ', 'milo', 'peanut']},
+                         index=pd.Index(['S1', 'S2', 'S3'], name='id')))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            with open(index_fp) as index_fh:
+                self.assertTrue('pet%2520name' in index_fh.read())
+            jsonp_fp = os.path.join(output_dir, 'shannon-pet%20name.jsonp')
+            self.assertTrue(os.path.exists(jsonp_fp))
+            with open(jsonp_fp) as jsonp_fh:
+                self.assertTrue('pet name' in jsonp_fh.read())
+
 
 class ComputeRarefactionDataTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #174 

---

Note to reviewer, this PR contains two logical commits - please rebase and merge.

The first commit is a bit of housekeeping related to leaking file handles, the second commit actually fixes #174.