### PR TITLE
ENH: Add error bars to alpha-rarefaction plots

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -367,6 +367,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
                        context={'metrics': list(metrics),
                                 'filenames': [quote(f) for f in filenames],
                                 'columns': list(columns),
+                                'steps': steps,
                                 'filtered_columns': sorted(filtered_columns)})
 
     shutil.copytree(os.path.join(TEMPLATES, 'alpha_rarefaction_assets',

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
@@ -52,7 +52,57 @@
           </g>
         </svg>
       </div>
-      <div class='col-lg-2' style='height: 1000px;'>
+      <div class='col-lg-2' style='height: 1050px;'>
+        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#helpModal">
+          Help
+        </button>
+        <div class="modal fade" id="helpModal" tabindex="-1" role="dialog">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                  <span>
+                    &times;
+                  </span>
+                </button>
+                <h4 class="modal-title" id="helpModalLabel">
+                  Alpha Diversity Help
+                </h4>
+              </div>
+              <div class="modal-body">
+                <p>
+                  In the legend below, click the box symbols to toggle the
+                  display of the line charts and click the circles to toggle
+                  the display of the box plots and scatter plots. If a color is
+                  visible in the symbol, the corresponding plot elements are
+                  displayed, otherwise they are hidden.
+                </p>
+
+                <p>
+                  The box plots in the upper figure represent the distribution
+                  of the selected alpha diversity metric at various depths.
+                  The lower and upper whiskers of the box plot are the 9th and
+                  91st percentiles of the distribution (respectively), while
+                  the lower and upper extents of the box are the 25th and 75th
+                  percentiles of the distribution (respectively). The
+                  horizontal bar through the middle of the box is the 50th
+                  percentile.
+                </p>
+
+                <p>
+                  The line chart in the upper figure is based on the 50th
+                  percentile values of the alpha diversity metric distribution
+                  at the specified sampling depths.
+                </p>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
         <div style='height: 25px; width: 300px; overflow-x: auto; overflow-y: hidden'>
           <svg width='200' height='20' class='legendTitleSvg'>
             <g class='legendTitle'></g>
@@ -72,6 +122,7 @@
   var d = {};
   var columns = {{ columns | safe }};
   var metrics = {{ metrics | safe }};
+  var steps = {{ steps | safe }};
   function load_data(metric, column, data) {
     if (column) {
       if (!d[metric]) {

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/index.html
@@ -80,19 +80,30 @@
 
                 <p>
                   The box plots in the upper figure represent the distribution
-                  of the selected alpha diversity metric at various depths.
-                  The lower and upper whiskers of the box plot are the 9th and
-                  91st percentiles of the distribution (respectively), while
-                  the lower and upper extents of the box are the 25th and 75th
-                  percentiles of the distribution (respectively). The
-                  horizontal bar through the middle of the box is the 50th
-                  percentile.
+                  of the selected alpha diversity metric for each group of
+                  samples at each even sampling depth. The lower and upper
+                  whiskers of the box plot are the 9th and 91st percentiles of
+                  the distribution (respectively), while the lower and upper
+                  extents of the box are the 25th and 75th percentiles of the
+                  distribution (respectively). The horizontal bar through the
+                  middle of the box is the median  of the dstribution
+                  (i.e., the 50th percentile). Outlier points of these
+                  distributions are not shown.
                 </p>
 
                 <p>
-                  The line chart in the upper figure is based on the 50th
-                  percentile values of the alpha diversity metric distribution
-                  at the specified sampling depths.
+                  The line chart in the upper figure connects the median
+                  values of the alpha diversity metric distribution
+                  across the sampling depths.
+                </p>
+
+                <p>
+                  If a sampling depth is higher than the number of sequences
+                  in a sample, that sample will not be included in the
+                  rarefaction plot at that sampling depth. The line chart in
+                  the lower figure illustrates the number of samples in each
+                  group (i.e., the sample size for each box plot) at each
+                  sampling depth.
                 </p>
               </div>
               <div class="modal-footer">

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/src/data.js
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/src/data.js
@@ -9,15 +9,17 @@ export function setupData(data, metric) {
   let minSubY = Infinity;
   let maxSubY = 0;
   const depthIndex = data.columns.indexOf('depth');
-  const medianIndex = data.columns.indexOf('50%');
+  const lowerWhiskerIndex = data.columns.indexOf('9%');
+  const upperWhiskerIndex = data.columns.indexOf('91%');
   const countIndex = data.columns.indexOf('count');
   data.data.forEach((d) => {
     const x = d[depthIndex];
-    const y = d[medianIndex];
     if (x < minX) minX = x;
     if (x > maxX) maxX = x;
-    if (y < minY) minY = y;
-    if (y > maxY) maxY = y;
+    const yMin = d[lowerWhiskerIndex];
+    const yMax = d[upperWhiskerIndex];
+    if (yMin < minY) minY = yMin;
+    if (yMax > maxY) maxY = yMax;
     const count = d[countIndex];
     if (count > maxSubY) maxSubY = count;
     if (count < minSubY) minSubY = count;
@@ -51,7 +53,7 @@ export function toggle(name, dots, line) {
     curData[name].dotsOpacity = dots === 'white' ? 0 : 1;
     // update chart
     state.getSvg()
-      .selectAll(`[class="circle ${name}"]`)
+      .selectAll(`[class="symbol ${name}"]`)
       .attr('opacity', curData[name].dotsOpacity);
   }
   if (line !== null) {


### PR DESCRIPTION
Fixes #179 

---

Questions for reviewer(s):

1) What do we think of this style of error bar? I went with simple, but can make quite a few alternatives happen here.
2) The legend symbol for the error bars is not my favorite --- it seems a bit too narrow (hard to click), but, making it wider makes it even harder to know what it does, IMO. I am open to alternatives.
3) Error bars are currently showing the 9%/91% values from the parametric 7-number summary. Should we be doing something else here?