### PR TITLE
ENH: Add procrustes analysis plugin

### DIFF
--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -11,6 +11,7 @@ from ._alpha import (alpha, alpha_phylogenetic, alpha_group_significance,
 from ._beta import (beta, beta_phylogenetic, beta_phylogenetic_alt, bioenv,
                     beta_group_significance, mantel, beta_rarefaction)
 from ._ordination import pcoa
+from ._procrustes import procrustes_analysis
 from ._core_metrics import core_metrics_phylogenetic, core_metrics
 from ._filter import filter_distance_matrix
 from ._version import get_versions
@@ -25,4 +26,4 @@ __all__ = ['beta', 'beta_phylogenetic', 'beta_phylogenetic_alt', 'alpha',
            'beta_group_significance', 'alpha_correlation',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',
-           'beta_rarefaction']
+           'beta_rarefaction', 'procrustes_analysis']

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -1,0 +1,64 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import pandas as pd
+
+from skbio import OrdinationResults
+from scipy.spatial import procrustes
+
+
+def procrustes_analysis(reference: OrdinationResults, other: OrdinationResults,
+                        dimensions: int=5) -> (OrdinationResults, OrdinationResults):
+
+    if reference.samples.shape != other.samples.shape:
+        raise ValueError('The matrices cannot be fitted unless they have the '
+                         'dimensions and samples')
+
+    if reference.samples.shape[1] < dimensions:
+        raise ValueError('Cannot fit fewer dimensions than available')
+
+    # fail if there are any elements in the symmetric difference
+    if not (reference.samples.index ^ other.samples.index).empty:
+        raise ValueError('The ordinations represent two different sets of '
+                         'samples')
+
+    # make the matrices be comparable
+    other.samples = other.samples.reindex(index=reference.samples.index)
+
+    mtx1, mtx2, _ = procrustes(reference.samples.values[:, :dimensions],
+                               other.samples.values[:, :dimensions])
+
+    axes = reference.samples.columns[:dimensions]
+    samples1 = pd.DataFrame(data=mtx1,
+                            index=reference.samples.index.copy(),
+                            columns=axes.copy())
+    samples2 = pd.DataFrame(data=mtx2,
+                            index=reference.samples.index.copy(),
+                            columns=axes.copy())
+
+    out1 = OrdinationResults(
+            short_method_name=reference.short_method_name,
+            long_method_name=reference.long_method_name,
+            eigvals=reference.eigvals[:dimensions].copy(),
+            samples=samples1,
+            features=reference.features,
+            biplot_scores=reference.biplot_scores,
+            sample_constraints=reference.sample_constraints,
+            proportion_explained=reference.proportion_explained[:dimensions]
+            .copy())
+    out2 = OrdinationResults(
+            short_method_name=other.short_method_name,
+            long_method_name=other.long_method_name,
+            eigvals=other.eigvals[:dimensions].copy(),
+            samples=samples2,
+            features=other.features,
+            biplot_scores=other.biplot_scores,
+            sample_constraints=other.sample_constraints,
+            proportion_explained=other.proportion_explained[:dimensions]
+            .copy())
+    return out1, out2

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -13,7 +13,8 @@ from scipy.spatial import procrustes
 
 
 def procrustes_analysis(reference: OrdinationResults, other: OrdinationResults,
-                        dimensions: int=5) -> (OrdinationResults, OrdinationResults):
+                        dimensions: int=5) -> (OrdinationResults,
+                                               OrdinationResults):
 
     if reference.samples.shape != other.samples.shape:
         raise ValueError('The matrices cannot be fitted unless they have the '

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -227,18 +227,18 @@ plugin.methods.register_function(
         ('transformed_other', PCoAResults)
     ],
     input_descriptions={
-        'reference': ('The ordination matrix to which data is fitted to'),
+        'reference': ('The ordination matrix to which data is fitted to.'),
         'other': ("The ordination matrix that's fitted to the reference "
                   "ordination.")
     },
     parameter_descriptions={},
     output_descriptions={
-        'transformed_reference': 'A normalized version of the original '
-                                 '"reference" ordination matrix',
-        'transformed_other': 'A normalized and fitted version of the original'
-                             ' "other" ordination matrix'},
+        'transformed_reference': 'A normalized version of the "reference" '
+                                 'ordination matrix.',
+        'transformed_other': 'A normalized and fitted version of the "other" '
+                             'ordination matrix.'},
     name='Procrustes Analysis',
-    description=("Fit two ordination matrices with Procrustes analysis")
+    description='Fit two ordination matrices with Procrustes analysis'
 )
 
 plugin.pipelines.register_function(

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -218,6 +218,29 @@ plugin.methods.register_function(
     description=("Apply principal coordinate analysis.")
 )
 
+plugin.methods.register_function(
+    function=q2_diversity.procrustes_analysis,
+    inputs={'reference': PCoAResults, 'other': PCoAResults},
+    parameters={'dimensions': Int % Range(1, None)},
+    outputs=[
+        ('transformed_reference', PCoAResults),
+        ('transformed_other', PCoAResults)
+    ],
+    input_descriptions={
+        'reference': ('The ordination matrix to which data is fitted to'),
+        'other': ("The ordination matrix that's fitted to the reference "
+                  "ordination.")
+    },
+    parameter_descriptions={},
+    output_descriptions={
+        'transformed_reference': 'A normalized version of the original '
+                                 '"reference" ordination matrix',
+        'transformed_other': 'A normalized and fitted version of the original'
+                             ' "other" ordination matrix'},
+    name='Procrustes Analysis',
+    description=("Fit two ordination matrices with Procrustes analysis")
+)
+
 plugin.pipelines.register_function(
     function=q2_diversity.core_metrics_phylogenetic,
     inputs={

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -1,0 +1,114 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2018, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import unittest
+
+import skbio
+import numpy as np
+import pandas as pd
+
+from q2_diversity import procrustes_analysis
+
+
+class PCoATests(unittest.TestCase):
+
+    def setUp(self):
+        axes = ['PC1', 'PC2', 'PC3', 'PC4', 'PC5', 'PC6']
+        eigvals = pd.Series(np.array([1.5, 0.75, 0.3, 0.15, 0.15, 0.15]),
+                            index=axes)
+        samples = np.array([[0, 3, 4, 4, 0, 0],
+                            [1, 2, 1, 4, 3, 3],
+                            [2, 3, 1, 0, 0, 1],
+                            [0, 3, 2, 4, 3, 0]])
+
+        proportion_explained = pd.Series([0.50, 0.25, 0.10, 0.05, 0.05, 0.05],
+                                         index=axes)
+        samples_df = pd.DataFrame(samples,
+                                  index=['A', 'B', 'C', 'D'],
+                                  columns=axes)
+        self.reference = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals,
+                samples_df,
+                proportion_explained=proportion_explained)
+
+        samples = np.array([[0.7, 3.7, 4.7, 4.7, 0.7, 0.7],
+                            [1.7, 2.7, 1.7, 4.7, 3.7, 3.7],
+                            [2.7, 3.7, 1.7, 0.7, 0.7, 1.7],
+                            [30, 3.7, 2.7, 4.7, 3.7, 0.7]])
+        samples_df = pd.DataFrame(samples,
+                                  index=['A', 'B', 'C', 'D'],
+                                  columns=axes)
+        self.other = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals.copy(),
+                samples_df.copy(),
+                proportion_explained=proportion_explained.copy())
+
+        S = [[-0.1358036, 0.0452679, 0.3621430, 0.1810715, -0.2716072],
+             [0.0452679, -0.1358036, -0.1810715, 0.1810715, 0.2716072],
+             [0.2263394, 0.0452679, -0.1810715, -0.5432145, -0.2716072],
+             [-0.1358036, 0.0452679, 0.0000000, 0.1810715, 0.2716072]]
+        samples_df = pd.DataFrame(np.array(S),
+                                  index=['A', 'B', 'C', 'D'],
+                                  columns=axes[:5])
+        self.expected_ref = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals[:5].copy(),
+                samples_df.copy(),
+                proportion_explained=proportion_explained[:5].copy())
+        S = [[0.0482731, -0.0324317, 0.0494312, -0.0316828, -0.1584374],
+             [0.0803620, -0.0718115, -0.0112234, -0.0171011, -0.1101209],
+             [0.0527554, -0.0042753, -0.0126739, -0.0969602, -0.0964822],
+             [-0.1813905, 0.1085184, -0.0255339, 0.1457440, 0.3650405]]
+        samples_df = pd.DataFrame(np.array(S),
+                                  index=['A', 'B', 'C', 'D'],
+                                  columns=axes[:5])
+        self.expected_other = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals[:5].copy(),
+                samples_df.copy(),
+                proportion_explained=proportion_explained[:5].copy())
+
+    def test_procrustes(self):
+        ref, other = procrustes_analysis(self.reference, self.other)
+
+        skbio.util.assert_ordination_results_equal(ref, self.expected_ref)
+        skbio.util.assert_ordination_results_equal(other, self.expected_other)
+
+    def test_procrustes_bad_dimensions(self):
+
+        self.other.samples = self.other.samples.iloc[:, :4]
+        self.other.eigvals = self.other.eigvals[:4]
+        self.other.proportion_explained = self.other.proportion_explained[:4]
+
+        with self.assertRaisesRegex(ValueError, 'The matrices cannot be '):
+            _ = procrustes_analysis(self.reference, self.other)
+
+    def test_procrustes_over_dimensions(self):
+        with self.assertRaisesRegex(ValueError, 'Cannot fit fewer dimensions '
+                                    'than available'):
+            _ = procrustes_analysis(self.reference, self.other, 11)
+
+    def test_procrustes_id_mismatch(self):
+        msg = 'The ordinations represent two different sets of samples'
+        self.other.samples.index = pd.Index([':L', ':D', ':)', ':('])
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = procrustes_analysis(self.reference, self.other)
+
+        self.other.samples.index = pd.Index([':L', 'B', 'C', 'D'])
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = procrustes_analysis(self.reference, self.other)
+
+        self.other.samples.index = pd.Index(['a', 'b', 'c', 'd'])
+        with self.assertRaisesRegex(ValueError, msg):
+            _ = procrustes_analysis(self.reference, self.other)

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -92,23 +92,23 @@ class PCoATests(unittest.TestCase):
         self.other.proportion_explained = self.other.proportion_explained[:4]
 
         with self.assertRaisesRegex(ValueError, 'The matrices cannot be '):
-            _ = procrustes_analysis(self.reference, self.other)
+            procrustes_analysis(self.reference, self.other)
 
     def test_procrustes_over_dimensions(self):
         with self.assertRaisesRegex(ValueError, 'Cannot fit fewer dimensions '
                                     'than available'):
-            _ = procrustes_analysis(self.reference, self.other, 11)
+            procrustes_analysis(self.reference, self.other, 11)
 
     def test_procrustes_id_mismatch(self):
         msg = 'The ordinations represent two different sets of samples'
         self.other.samples.index = pd.Index([':L', ':D', ':)', ':('])
         with self.assertRaisesRegex(ValueError, msg):
-            _ = procrustes_analysis(self.reference, self.other)
+            procrustes_analysis(self.reference, self.other)
 
         self.other.samples.index = pd.Index([':L', 'B', 'C', 'D'])
         with self.assertRaisesRegex(ValueError, msg):
-            _ = procrustes_analysis(self.reference, self.other)
+            procrustes_analysis(self.reference, self.other)
 
         self.other.samples.index = pd.Index(['a', 'b', 'c', 'd'])
         with self.assertRaisesRegex(ValueError, msg):
-            _ = procrustes_analysis(self.reference, self.other)
+            procrustes_analysis(self.reference, self.other)


### PR DESCRIPTION
Solves the procrustes problem for two ordination matrices. While we can
support N different matrices as inputs, we can't support varidic
outputs, hence this will be deferred to a later PR when the
functionality is available in the framework.