### PR TITLE
ENH: Add error message when md is fully filtered

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -325,6 +325,9 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
         filtered_columns = pre_filtered_cols - set(metadata.columns)
 
         metadata_df = metadata.to_dataframe()
+        if metadata_df.empty or len(metadata.columns) == 0:
+            raise ValueError("All metadata filtered after dropping columns "
+                             "that contained non-categorical data.")
         metadata_df.columns = pd.MultiIndex.from_tuples(
             [(c, '') for c in metadata_df.columns])
         columns = metadata_df.columns.get_level_values(0)

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -219,6 +219,19 @@ class AlphaRarefactionTests(unittest.TestCase):
             with open(jsonp_fp) as jsonp_fh:
                 self.assertTrue('pet name' in jsonp_fh.read())
 
+    def test_alpha_rarefaction_with_fully_filtered_metadata_columns(self):
+        t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
+                       ['O1', 'O2'],
+                       ['S1', 'S2', 'S3'])
+        # All columns should both be filtered and raise an error
+        md = qiime2.Metadata(
+            pd.DataFrame({'foo': [np.nan, np.nan, np.nan, 'bar'],
+                          'bar': [42, 4.2, 99.9, 100.0]},
+                         index=pd.Index(['S1', 'S2', 'S3', 'S4'], name='id')))
+        with tempfile.TemporaryDirectory() as output_dir:
+            with self.assertRaisesRegex(ValueError, "non-categorical"):
+                alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
+
 
 class ComputeRarefactionDataTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Adds a clear error message when all metadata is filtered out from the table - due to non-categorical data being dropped. 

Resolves #199 