### PR TITLE
ENH: Add pcoa biplot method

### DIFF
--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -11,7 +11,7 @@ from ._alpha import (alpha, alpha_phylogenetic, alpha_group_significance,
 from ._beta import (beta, beta_phylogenetic, beta_phylogenetic_alt, bioenv,
                     beta_group_significance, mantel, beta_rarefaction,
                     beta_correlation)
-from ._ordination import pcoa
+from ._ordination import pcoa, pcoa_biplot
 from ._procrustes import procrustes_analysis
 from ._core_metrics import core_metrics_phylogenetic, core_metrics
 from ._filter import filter_distance_matrix
@@ -23,7 +23,8 @@ del get_versions
 
 
 __all__ = ['beta', 'beta_phylogenetic', 'beta_phylogenetic_alt', 'alpha',
-           'alpha_phylogenetic', 'pcoa', 'alpha_group_significance', 'bioenv',
+           'alpha_phylogenetic', 'pcoa', 'pcoa_biplot',
+           'alpha_group_significance', 'bioenv',
            'beta_group_significance', 'alpha_correlation',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',

--- a/q2_diversity/_ordination.py
+++ b/q2_diversity/_ordination.py
@@ -7,7 +7,13 @@
 # ----------------------------------------------------------------------------
 
 import skbio.stats.ordination
+import pandas as pd
 
 
 def pcoa(distance_matrix: skbio.DistanceMatrix) -> skbio.OrdinationResults:
     return skbio.stats.ordination.pcoa(distance_matrix)
+
+
+def pcoa_biplot(pcoa: skbio.OrdinationResults,
+                features: pd.DataFrame) -> skbio.OrdinationResults:
+    return skbio.stats.ordination.pcoa_biplot(pcoa, features)

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -162,3 +162,13 @@
   year={1904},
   publisher={JSTOR}
 }
+
+@inbook{legendrelegendre,
+  author    = {Pierre Legendre and Louis Legendre},
+  title     = {Numerical Ecology},
+  publisher = {Elsevier},
+  year      = {2012},
+  isbn      = {0444-89249},
+  edition   = {Third},
+  pages     = {499}
+}

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -231,10 +231,10 @@ plugin.methods.register_function(
     output_descriptions={'biplot': 'The resulting PCoA matrix.'},
     name='Principal Coordinate Analysis Biplot',
     description="Project features into a principal coordinates matrix. The "
-                "features used can be environmental variables or the features"
-                " used to compute the distance matrix. It is recommended that"
-                " these variables be normalized in cases of dimensionally "
-                "heterogeneous physical variables.",
+                "features used should be the features used to compute the "
+                "distance matrix. It is recommended that these variables be"
+                " normalized in cases of dimensionally heterogeneous physical"
+                " variables.",
     citations=[citations['legendrelegendre']]
 )
 

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -13,7 +13,7 @@ from qiime2.plugin import (Plugin, Str, Properties, Choices, Int, Bool, Range,
 import q2_diversity
 from q2_diversity import _alpha as alpha
 from q2_diversity import _beta as beta
-from q2_types.feature_table import FeatureTable, Frequency
+from q2_types.feature_table import FeatureTable, Frequency, RelativeFrequency
 from q2_types.distance_matrix import DistanceMatrix
 from q2_types.sample_data import AlphaDiversity, SampleData
 from q2_types.tree import Phylogeny, Rooted
@@ -215,6 +215,27 @@ plugin.methods.register_function(
     output_descriptions={'pcoa': 'The resulting PCoA matrix.'},
     name='Principal Coordinate Analysis',
     description=("Apply principal coordinate analysis.")
+)
+
+plugin.methods.register_function(
+    function=q2_diversity.pcoa_biplot,
+    inputs={'pcoa': PCoAResults,
+            'features': FeatureTable[RelativeFrequency]},
+    parameters={},
+    outputs=[('biplot', PCoAResults)],
+    input_descriptions={
+        'pcoa': 'The PCoA where the features will be projected onto.',
+        'features': 'Variables to project onto the PCoA matrix'
+    },
+    parameter_descriptions={},
+    output_descriptions={'biplot': 'The resulting PCoA matrix.'},
+    name='Principal Coordinate Analysis Biplot',
+    description="Project features into a principal coordinates matrix. The "
+                "features used can be environmental variables or the features"
+                " used to compute the distance matrix. It is recommended that"
+                " these variables be normalized in cases of dimensionally "
+                "heterogeneous physical variables.",
+    citations=[citations['legendrelegendre']]
 )
 
 plugin.methods.register_function(

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -222,7 +222,7 @@ plugin.methods.register_function(
     inputs={'pcoa': PCoAResults,
             'features': FeatureTable[RelativeFrequency]},
     parameters={},
-    outputs=[('biplot', PCoAResults)],
+    outputs=[('biplot', PCoAResults % Properties('biplot'))],
     input_descriptions={
         'pcoa': 'The PCoA where the features will be projected onto.',
         'features': 'Variables to project onto the PCoA matrix'

--- a/q2_diversity/tests/test_ordination.py
+++ b/q2_diversity/tests/test_ordination.py
@@ -9,18 +9,33 @@
 import unittest
 
 import skbio
+import pandas as pd
 
-from q2_diversity import pcoa
+from q2_diversity import pcoa, pcoa_biplot
 
 
 class PCoATests(unittest.TestCase):
 
+    def setUp(self):
+        self.dm = skbio.DistanceMatrix([[0.0000000, 0.3333333, 0.6666667],
+                                        [0.3333333, 0.0000000, 0.4285714],
+                                        [0.6666667, 0.4285714, 0.0000000]],
+                                       ids=['S1', 'S2', 'S3'])
+        self.ordination = skbio.stats.ordination.pcoa(self.dm)
+
     def test_pcoa(self):
-        dm = skbio.DistanceMatrix([[0.0000000, 0.3333333, 0.6666667],
-                                   [0.3333333, 0.0000000, 0.4285714],
-                                   [0.6666667, 0.4285714, 0.0000000]],
-                                  ids=['S1', 'S2', 'S3'])
-        actual = pcoa(dm)
-        expected = skbio.stats.ordination.pcoa(dm)
+        observed = pcoa(self.dm)
         skbio.util.assert_ordination_results_equal(
-            actual, expected, ignore_directionality=True)
+            observed, self.ordination, ignore_directionality=True)
+
+    def test_pcoa_biplot(self):
+        features = pd.DataFrame([[1, 0], [3, 0.1], [8, -0.4]],
+                                index=['S1', 'S2', 'S3'],
+                                columns=['positive', 'neither'])
+
+        expected = skbio.stats.ordination.pcoa_biplot(self.ordination,
+                                                      features)
+        observed = pcoa_biplot(self.ordination, features)
+
+        skbio.util.assert_ordination_results_equal(observed, expected,
+                                                   ignore_directionality=True)


### PR DESCRIPTION
Allows users to project descriptors into an existing PCoA matrix

Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

Adds a new method to project variables into a PCoA matrix. This depends on busywork to update the conda recipe (as the method depends on scikit-bio 0.5.3).

A subsequent q2-emperor PR will allow for users to see these results.

**questions**:

I wondered whether or not I should add an annotation to the PCoAResults type. Namely something like `PCoAResults[Biplot]`. This way this method would output a `PCoAResults[Biplot]` artifact that can only be consumed by `q2-emperor`'s `biplot` method. If reviewers think this makes sense, I'll add the proper changes in q2-types.