### PR TITLE
ENH: Add permdisp as a group significance method

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -69,7 +69,8 @@ def bioenv(output_dir: str, distance_matrix: skbio.DistanceMatrix,
 
 
 _beta_group_significance_fns = {'permanova': skbio.stats.distance.permanova,
-                                'anosim': skbio.stats.distance.anosim}
+                                'anosim': skbio.stats.distance.anosim,
+                                'permdisp': skbio.stats.distance.permdisp}
 
 
 def _get_distance_boxplot_data(distance_matrix, group_id, groupings):


### PR DESCRIPTION
Adds permdisp to the beta-group-significance method.