### PR TITLE
Canberra Adkins form

### DIFF
--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -43,7 +43,7 @@ def non_phylogenetic_metrics():
             'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
             'braycurtis', 'mahalanobis', 'yule', 'matching', 'dice',
             'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
-            'sokalsneath', 'wminkowski', 'aitchison', 'canberra-adkins'}
+            'sokalsneath', 'wminkowski', 'aitchison', 'canberra_adkins'}
 
 
 def all_metrics():

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -126,7 +126,6 @@ def beta(table: biom.Table, metric: str,
         return euclidean(clr(x), clr(y))
 
     def canberra_adkins(x, y, **kwds):
-        # Table 1 of Faith et al 1987 Plant Ecology 69: 57-68
         if (x < 0).any() or (y < 0).any():
             raise ValueError("Canberra-Adkins is only defined over positive "
                              "values.")

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -141,7 +141,7 @@ def beta(table: biom.Table, metric: str,
     if metric == 'aitchison':
         counts += pseudocount
         metric = aitchison
-    elif metric == 'canberra-adkins':
+    elif metric == 'canberra_adkins':
         metric = canberra_adkins
 
     if table.is_empty():

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -14,6 +14,7 @@ import skbio.tree
 import sklearn.metrics
 import unifrac
 import psutil
+import numpy as np
 
 from q2_types.feature_table import BIOMV210Format
 from q2_types.tree import NewickFormat
@@ -42,7 +43,7 @@ def non_phylogenetic_metrics():
             'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
             'braycurtis', 'mahalanobis', 'yule', 'matching', 'dice',
             'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
-            'sokalsneath', 'wminkowski', 'aitchison'}
+            'sokalsneath', 'wminkowski', 'aitchison', 'canberra-adkins'}
 
 
 def all_metrics():
@@ -124,9 +125,23 @@ def beta(table: biom.Table, metric: str,
     def aitchison(x, y, **kwds):
         return euclidean(clr(x), clr(y))
 
+    def canberra_adkins(x, y, **kwds):
+        if (x < 0).any() or (y < 0).any():
+            raise ValueError("Canberra-Adkins is only defined over positive "
+                             "values.")
+
+        nz = ((x > 0) | (y > 0))
+        x_ = x[nz]
+        y_ = y[nz]
+        nnz = nz.sum()
+
+        return (1. / nnz) * np.sum(np.abs(x_ - y_) / (x_ + y_))
+
     if metric == 'aitchison':
         counts += pseudocount
         metric = aitchison
+    elif metric == 'canberra-adkins':
+        metric = canberra_adkins
 
     if table.is_empty():
         raise ValueError("The provided table object is empty")

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -126,6 +126,7 @@ def beta(table: biom.Table, metric: str,
         return euclidean(clr(x), clr(y))
 
     def canberra_adkins(x, y, **kwds):
+        # Table 1 of Faith et al 1987 Plant Ecology 69: 57-68
         if (x < 0).any() or (y < 0).any():
             raise ValueError("Canberra-Adkins is only defined over positive "
                              "values.")

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -172,3 +172,15 @@
   edition   = {Third},
   pages     = {499}
 }
+
+@Article{Faith1987,
+  author={Faith, Daniel P. and Minchin, Peter R. and Belbin, Lee},
+  title={Compositional dissimilarity as a robust measure of ecological distance},
+  journal={Vegetatio},
+  year={1987},
+  volume={69},
+  number={1},
+  pages={57--68},
+  abstract={The robustness of quantitative measures of compositional dissimilarity between sites was evaluated using extensive computer simulations of species' abundance patterns over one and two dimensional configurations of sample sites in ecological space. Robustness was equated with the strength over a range of models, of the linear and monotonic (rank-order) relationship between the compositional dissimilarities and the corresponding Euclidean distances between sites measured in the ecological space. The range of models reflected different assumptions about species' response curve shape, sampling pattern of sites, noise level of the data, species' interactions, trends in total site abundance, and beta diversity of gradients.},
+  doi="10.1007/BF00038687",
+}

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -150,7 +150,9 @@ plugin.methods.register_function(
     output_descriptions={'distance_matrix': 'The resulting distance matrix.'},
     name='Beta diversity',
     description=("Computes a user-specified beta diversity metric for all "
-                 "pairs of samples in a feature table.")
+                 "pairs of samples in a feature table."),
+    citations=[
+        citations['Faith1987']]
 )
 
 plugin.methods.register_function(

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -46,9 +46,9 @@ class BetaDiversityTests(unittest.TestCase):
                 npt.assert_almost_equal(actual[id1, id2], expected[id1, id2])
 
     def test_beta_canberra_adkins(self):
-        t = biom.Table(np.array([[0, 0], [0, 1], [1, 2]]),
-                       ['O1', 'O2', 'O3'],
-                       ['S1', 'S2'])
+        t = Table(np.array([[0, 0], [0, 1], [1, 2]]),
+                  ['O1', 'O2', 'O3'],
+                  ['S1', 'S2'])
         d = (1. / 2.) * sum([abs(0. - 1.) / (0. + 1.),
                              abs(1. - 2.) / (1. + 2.)])
         expected = skbio.DistanceMatrix(np.array([[0.0, d], [d, 0.0]]),

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -45,6 +45,21 @@ class BetaDiversityTests(unittest.TestCase):
             for id2 in actual.ids:
                 npt.assert_almost_equal(actual[id1, id2], expected[id1, id2])
 
+    def test_beta_canberra_adkins(self):
+        t = biom.Table(np.array([[0, 0], [0, 1], [1, 2]]),
+                       ['O1', 'O2', 'O3'],
+                       ['S1', 'S2'])
+        d = (1. / 2.) * sum([abs(0. - 1.) / (0. + 1.),
+                             abs(1. - 2.) / (1. + 2.)])
+        expected = skbio.DistanceMatrix(np.array([[0.0, d], [d, 0.0]]),
+                                        ids=['S1', 'S2'])
+        actual = beta(table=t, metric='canberra-adkins')
+
+        self.assertEqual(actual.ids, expected.ids)
+        for id1 in actual.ids:
+            for id2 in actual.ids:
+                npt.assert_almost_equal(actual[id1, id2], expected[id1, id2])
+
     def test_parallel_beta(self):
         t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                   ['O1', 'O2'],

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -53,7 +53,7 @@ class BetaDiversityTests(unittest.TestCase):
                              abs(1. - 2.) / (1. + 2.)])
         expected = skbio.DistanceMatrix(np.array([[0.0, d], [d, 0.0]]),
                                         ids=['S1', 'S2'])
-        actual = beta(table=t, metric='canberra-adkins')
+        actual = beta(table=t, metric='canberra_adkins')
 
         self.assertEqual(actual.ids, expected.ids)
         for id1 in actual.ids:


### PR DESCRIPTION
This pull request introduces Canberra-Adkins, which is a normalized variant of the Canberra metric. This metric is more similar, although not identical, to the "Canberra" metric of QIIME1. The slight difference stems from a bug in the QIIME1 implementation in which the number of nonzero elements used in the scaling factor was over estimated. 

Co-authors on this include: @gregcaporaso @antgonza @ElDeveloper @rob-knight and @justin212k following internal discussion. The discrepancy with QIIME1 and QIIME2 was first identified by Dr. Alexey Melnik.

TODO: 

* Is the `ValueError` necessary, or does the `validate=True` in `beta_diversity` assure the values are positive?