### PR TITLE
ENH: batch alpha calculations to reduce table / tree size

### DIFF
--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -48,7 +48,6 @@ def alpha_phylogenetic(table: biom.Table, phylogeny: skbio.TreeNode,
 
     results = []
     for counts, sample_ids, feature_ids in _batch_table(table):
-
         try:
             result = skbio.diversity.alpha_diversity(metric=metric,
                                                      counts=counts,
@@ -72,10 +71,11 @@ def alpha(table: biom.Table, metric: str) -> pd.Series:
     if table.is_empty():
         raise ValueError("The provided table object is empty")
 
-    counts = table.matrix_data.toarray().astype(int).T
-    sample_ids = table.ids(axis='sample')
+    results = []
+    for counts, sample_ids, _ in _batch_table(table):
+        result = skbio.diversity.alpha_diversity(metric=metric, counts=counts,
+                                                 ids=sample_ids)
+        result.name = metric
+        results.append(result)
 
-    result = skbio.diversity.alpha_diversity(metric=metric, counts=counts,
-                                             ids=sample_ids)
-    result.name = metric
-    return result
+    return pd.concat(results)

--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -31,6 +31,10 @@ def _batch_table(table, batchsize=1000):
     # always have at least 1 partition
     n_partitions = (len(table.ids()) / batchsize) + 1
     for id_split in np.array_split(table.ids(), n_partitions):
+        # catch case of batchsize == len(table.ids())
+        if not len(id_split):
+            continue
+
         subset = table.filter(set(id_split), inplace=False).remove_empty()
 
         counts = subset.matrix_data.toarray().astype(int).T

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -106,7 +106,7 @@ def beta_phylogenetic(table: BIOMV210Format, phylogeny: NewickFormat,
 
 
 def beta(table: biom.Table, metric: str,
-         pseudocount: int = 1, n_jobs: int = 1)-> skbio.DistanceMatrix:
+         pseudocount: int = 1, n_jobs: int = 1) -> skbio.DistanceMatrix:
 
     if not (metric in non_phylogenetic_metrics()):
         raise ValueError("Unknown metric: %s" % metric)


### PR DESCRIPTION
The alpha calculation code casts the input feature table into a dense representation. For large studies, this represents a large memory requirement. This memory requirement is further increased for Faith's PD as, with the present implementation, an intermediary counts array is produced that is N * M where N is the number of samples and M is the number of vertices in the tree.

This code automatically partitions the input feature table into smaller sizes, and then aggregates the resulting alpha diversity scores into a single pandas `Series`. 

I opted to not expose the `batch_size` parameter as 1000 is pretty large, but small enough that even for a table with 1M features, the memory footprint is reasonably small. The downside to a smaller batch size is it increases the number of executions of `alpha_diversity` and the associated validation overhead. 