### PR TITLE
BUG: More useful error message when metadata column name too long

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -111,6 +111,10 @@ def alpha_group_significance(output_dir: str, alpha_diversity: pd.Series,
             kw_H_pairwise['p-value'], method='fdr_bh')[1]
         kw_H_pairwise.sort_index(inplace=True)
         pairwise_fn = 'kruskal-wallis-pairwise-%s.csv' % escaped_column
+        # Make sure the filename isn't too long to be a filename
+        if len(pairwise_fn) > os.statvfs(output_dir).f_namemax:
+            raise ValueError(f'Length of metadata column {column} exceeds '
+                             'maximum metada column name length.')
         pairwise_path = os.path.join(output_dir, pairwise_fn)
         kw_H_pairwise.to_csv(pairwise_path)
 


### PR DESCRIPTION
Begins to close qiime2/qiime2#463 at least in this particular instance. The current error message is mostly a placeholder until something better can be finalized. If there is a way to tackle this in the actual framework then awesome, but I'm not seeing it :confounded: .