### PR TITLE
adonis view_type: str->int

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -339,7 +339,7 @@ def adonis(output_dir: str,
            metadata: qiime2.Metadata,
            formula: str,
            permutations: int = 999,
-           n_jobs: str = 1) -> None:
+           n_jobs: int = 1) -> None:
     # Validate sample metadata is superset et cetera
     metadata_ids = set(metadata.ids)
     dm_ids = distance_matrix.ids


### PR DESCRIPTION
Last week a Qiita user reported an error with Adonis, which turned out to be a problem with its parameters definition, to see the problem:
```
import qiime2 
pm = qiime2.sdk.PluginManager()
adonis = pm.plugins['diversity'].actions['adonis']
In [27]: adonis.signature.parameters['n_jobs']                                                                                                                                                                                                   
Out[27]: ParameterSpec(qiime_type=Int % Range(1, None), view_type=<class 'str'>, default=1, description='Number of parallel processes to run.')
```
If you see we have qiime_type=Int % Range(1, None) but view_type=<class ‘str’>; then if you pass a string to the method, it will raise: “Error running: Parameter ‘n_jobs’ received ‘1’ as an argument, which is incompatible with parameter type: Int % Range(1, None)“. Remember that qiita uses the view_type to decide if it should use the `qiime_type.decode` to transform the parameter and as this is a str, it does apply it 