### PR TITLE
up unifrac version to expose high performance faith's pd

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - psutil
     - natsort
     - biom-format >=2.1.5,<2.2.0
-    - unifrac >=0.9.2,<0.10.0
+    - unifrac >=0.10.0
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
This PR ups the required version of `unifrac` to expose Faith's PD via `unifrac` in order to trigger QIIME2 continuous integration prior to `q2_alpha_phylogenetic_alt` functionality can be properly tested in #251 
