### PR TITLE
ENH: core-metrics can subsample with replacement

### DIFF
--- a/q2_diversity/_core_metrics.py
+++ b/q2_diversity/_core_metrics.py
@@ -7,7 +7,8 @@
 # ----------------------------------------------------------------------------
 
 
-def core_metrics(ctx, table, sampling_depth, metadata, n_jobs=1):
+def core_metrics(ctx, table, sampling_depth, metadata, with_replacement=False,
+                 n_jobs=1):
     rarefy = ctx.get_action('feature_table', 'rarefy')
     alpha = ctx.get_action('diversity', 'alpha')
     beta = ctx.get_action('diversity', 'beta')
@@ -15,7 +16,8 @@ def core_metrics(ctx, table, sampling_depth, metadata, n_jobs=1):
     emperor_plot = ctx.get_action('emperor', 'plot')
 
     results = []
-    rarefied_table, = rarefy(table=table, sampling_depth=sampling_depth)
+    rarefied_table, = rarefy(table=table, sampling_depth=sampling_depth,
+                             with_replacement=with_replacement)
     results.append(rarefied_table)
 
     for metric in 'observed_otus', 'shannon', 'pielou_e':

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -376,6 +376,7 @@ plugin.pipelines.register_function(
     parameters={
         'sampling_depth': Int % Range(1, None),
         'metadata': Metadata,
+        'with_replacement': Bool,
         'n_jobs': Int % Range(0, None),
     },
     outputs=[
@@ -398,6 +399,9 @@ plugin.pipelines.register_function(
         'sampling_depth': 'The total frequency that each sample should be '
                           'rarefied to prior to computing diversity metrics.',
         'metadata': 'The sample metadata to use in the emperor plots.',
+        'with_replacement': 'Rarefy with replacement by sampling from the '
+                            'multinomial distribution instead of rarefying '
+                            'without replacement.',
         'n_jobs': '[beta methods only] - %s' % sklearn_n_jobs_description
     },
     output_descriptions={


### PR DESCRIPTION
This is convenient for the analysis of metabolomic datasets where
subsampling with replacement is time-consuming based on the scale of the
feature counts.

Perhaps this PR should also include an update to `core-metrics-phylogenetic`. I'm happy to add that as long as we think it makes sense.