### PR TITLE
FIX: problem with wrong encoded filenames, closes #197

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -191,9 +191,9 @@ def beta_group_significance(output_dir: str,
         plt.tight_layout()
         fig = ax.get_figure()
         fig.savefig(os.path.join(output_dir, '%s-boxplots.png' %
-                                 urllib.parse.quote_plus(str(group_id))))
+                                 str(group_id)))
         fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' %
-                                 urllib.parse.quote_plus(str(group_id))))
+                                 str(group_id)))
         fig.clear()
 
     pairs_summary.to_csv(os.path.join(output_dir, 'raw_data.tsv'), sep='\t')

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -8,7 +8,6 @@
 
 import os.path
 import collections
-import urllib.parse
 import pkg_resources
 import itertools
 import tempfile

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -119,6 +119,10 @@ def _get_pairwise_group_significance_stats(
                                       permutations=permutations)
 
 
+def escape_chars(charlist):
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in charlist)
+
+
 def beta_group_significance(output_dir: str,
                             distance_matrix: skbio.DistanceMatrix,
                             metadata: qiime2.CategoricalMetadataColumn,
@@ -189,10 +193,11 @@ def beta_group_significance(output_dir: str,
         sns.despine()
         plt.tight_layout()
         fig = ax.get_figure()
-        fig.savefig(os.path.join(output_dir, '%s-boxplots.png' %
-                                 str(group_id)))
-        fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' %
-                                 str(group_id)))
+
+        group_id = escape_chars(group_id)
+
+        fig.savefig(os.path.join(output_dir, '%s-boxplots.png' % group_id))
+        fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' % group_id))
         fig.clear()
 
     pairs_summary.to_csv(os.path.join(output_dir, 'raw_data.tsv'), sep='\t')
@@ -233,7 +238,8 @@ def beta_group_significance(output_dir: str,
         pairwise_results_html = None
 
     # repartition groupings for rendering
-    group_ids = list(groupings.keys())
+    group_ids = [escape_chars(group_id) for group_id in list(groupings.keys())]
+
     row_count, group_count = 3, len(group_ids)  # Start at three plots per row
     while group_count % row_count != 0:
         row_count = row_count - 1

--- a/q2_diversity/_beta/beta_group_significance_assets/index.html
+++ b/q2_diversity/_beta/beta_group_significance_assets/index.html
@@ -27,8 +27,8 @@
         <div class="row">
           {% for group_id in group_row %}
             <div class="col-lg-{{ bootstrap_group_col_size }} text-center">
-              <a href="{{ group_id | replace(' ', '+') }}-boxplots.pdf">
-                <img src="{{ group_id | replace(' ', '+') }}-boxplots.png">
+              <a href="{{ group_id }}-boxplots.pdf">
+                <img src="{{ group_id }}-boxplots.png">
                 <br>
                 <p>Download as PDF</p>
               </a>


### PR DESCRIPTION
This fixed my problem with misencoded filenames in `qiime diversity beta-group-significance` , closes #197

I had problems with groupnames like _NucleoSpin® Soil - Macherey Nagel_.
The file is saved as _NucleoSpin%C2%AE+Soil+-+Macherey+Nagel-boxplots.pdf_ and linked in the HTML-file as _NucleoSpin®+Soil+-+Macherey+Nagel-boxplots.pdf_.

Removing the encoding parts worked. Tested with FF 69.0.1 (64-bit), Chromium 77.0.3865.90.





