### PR TITLE
BUG: fix escaping of filenames in beta-group-sig

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -191,9 +191,9 @@ def beta_group_significance(output_dir: str,
         plt.tight_layout()
         fig = ax.get_figure()
         fig.savefig(os.path.join(output_dir, '%s-boxplots.png' %
-                                 urllib.parse.quote_plus(str(group_id))))
+                                 urllib.parse.quote(str(group_id))))
         fig.savefig(os.path.join(output_dir, '%s-boxplots.pdf' %
-                                 urllib.parse.quote_plus(str(group_id))))
+                                 urllib.parse.quote(str(group_id))))
         fig.clear()
 
     pairs_summary.to_csv(os.path.join(output_dir, 'raw_data.tsv'), sep='\t')
@@ -240,7 +240,7 @@ def beta_group_significance(output_dir: str,
         # however, as a result, our links need to escape % so that the browser
         # asks for the right escaped name (instead of the original name, which
         # doesn't exist inside the visualization).
-        urllib.parse.quote_plus(urllib.parse.quote_plus(k))
+        urllib.parse.quote(urllib.parse.quote(k))
         for k in groupings.keys()
     ]
     row_count, group_count = 3, len(group_ids)  # Start at three plots per row

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -234,7 +234,15 @@ def beta_group_significance(output_dir: str,
         pairwise_results_html = None
 
     # repartition groupings for rendering
-    group_ids = list(groupings.keys())
+    group_ids = [
+        # We have to DOUBLE encode this, as the file/resource name is a literal
+        # URI-encoded string, we do this to prevent issues with the filesystem
+        # however, as a result, our links need to escape % so that the browser
+        # asks for the right escaped name (instead of the original name, which
+        # doesn't exist inside the visualization).
+        urllib.parse.quote_plus(urllib.parse.quote_plus(k))
+        for k in groupings.keys()
+    ]
     row_count, group_count = 3, len(group_ids)  # Start at three plots per row
     while group_count % row_count != 0:
         row_count = row_count - 1

--- a/q2_diversity/_beta/beta_group_significance_assets/index.html
+++ b/q2_diversity/_beta/beta_group_significance_assets/index.html
@@ -27,8 +27,8 @@
         <div class="row">
           {% for group_id in group_row %}
             <div class="col-lg-{{ bootstrap_group_col_size }} text-center">
-              <a href="{{ group_id | replace(' ', '+') }}-boxplots.pdf">
-                <img src="{{ group_id | replace(' ', '+') }}-boxplots.png">
+              <a href="{{ group_id }}-boxplots.pdf">
+                <img src="{{ group_id }}-boxplots.png">
                 <br>
                 <p>Download as PDF</p>
               </a>


### PR DESCRIPTION
It turns out this does kind of makes sense, it's just super weird.

Many thanks to @angrybee for the [initial legwork here](https://github.com/qiime2/q2-diversity/pull/263#issuecomment-539444693).