### PR TITLE
Added jensenshannon metric

### DIFF
--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -111,7 +111,7 @@ def beta(table: biom.Table, metric: str,
 
         return (1. / nnz) * np.sum(np.abs(x_ - y_) / (x_ + y_))
 
-    def jensenshannon(x, y, **kwds):
+    def jensen_shannon(x, y, **kwds):
         return jensenshannon(x, y)
 
     if metric == 'aitchison':
@@ -120,7 +120,7 @@ def beta(table: biom.Table, metric: str,
     elif metric == 'canberra_adkins':
         metric = canberra_adkins
     elif metric == 'jensenshannon':
-        metric = jensenshannon
+        metric = jensen_shannon
 
     if table.is_empty():
         raise ValueError("The provided table object is empty")

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -40,7 +40,8 @@ def non_phylogenetic_metrics():
             'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
             'braycurtis', 'mahalanobis', 'yule', 'matching', 'dice',
             'kulsinski', 'rogerstanimoto', 'russellrao', 'sokalmichener',
-            'sokalsneath', 'wminkowski', 'aitchison', 'canberra_adkins'}
+            'sokalsneath', 'wminkowski', 'aitchison', 'canberra_adkins',
+            'jensenshannon'}
 
 
 def all_metrics():

--- a/q2_diversity/_beta/_method.py
+++ b/q2_diversity/_beta/_method.py
@@ -22,6 +22,7 @@ from functools import partial
 
 from skbio.stats.composition import clr
 from scipy.spatial.distance import euclidean
+from scipy.spatial.distance import jensenshannon
 
 
 def phylogenetic_metrics_dict():
@@ -110,11 +111,16 @@ def beta(table: biom.Table, metric: str,
 
         return (1. / nnz) * np.sum(np.abs(x_ - y_) / (x_ + y_))
 
+    def jensenshannon(x, y, **kwds):
+        return jensenshannon(x, y)
+
     if metric == 'aitchison':
         counts += pseudocount
         metric = aitchison
     elif metric == 'canberra_adkins':
         metric = canberra_adkins
+    elif metric == 'jensenshannon':
+        metric = jensenshannon
 
     if table.is_empty():
         raise ValueError("The provided table object is empty")

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -68,7 +68,7 @@ class BetaDiversityTests(TestPluginBase):
                   ['S1', 'S2', 'S3'])
         actual = beta(table=t, metric='jensenshannon')
         # expected computed with scipy.spatial.distance.jensenshannon
-        expected = skbio.DistanceMatrix([[0.0000000, 0.4645014 , 0.52379239],
+        expected = skbio.DistanceMatrix([[0.0000000, 0.4645014, 0.52379239],
                                          [0.4645014, 0.0000000, 0.07112939],
                                          [0.52379239, 0.07112939, 0.0000000]],
                                         ids=['S1', 'S2', 'S3'])

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -69,10 +69,10 @@ class BetaDiversityTests(TestPluginBase):
         actual = beta(table=t, metric='jensenshannon')
         # expected computed with scipy.spatial.distance.jensenshannon
         expected = skbio.DistanceMatrix([[0.0000000, 0.4645014 , 0.52379239],
-                                         [0.4645014 , 0.0000000, 0.07112939],
+                                         [0.4645014, 0.0000000, 0.07112939],
                                          [0.52379239, 0.07112939, 0.0000000]],
                                         ids=['S1', 'S2', 'S3'])
-                                        
+
         self.assertEqual(actual.ids, expected.ids)
         for id1 in actual.ids:
             for id2 in actual.ids:

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -62,6 +62,22 @@ class BetaDiversityTests(TestPluginBase):
             for id2 in actual.ids:
                 npt.assert_almost_equal(actual[id1, id2], expected[id1, id2])
 
+    def test_beta_jensenshannon(self):
+        t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
+                  ['O1', 'O2'],
+                  ['S1', 'S2', 'S3'])
+        actual = beta(table=t, metric='jensenshannon')
+        # expected computed with scipy.spatial.distance.jensenshannon
+        expected = skbio.DistanceMatrix([[0.0000000, 0.4645014 , 0.52379239],
+                                         [0.4645014 , 0.0000000, 0.07112939],
+                                         [0.52379239, 0.07112939, 0.0000000]],
+                                        ids=['S1', 'S2', 'S3'])
+                                        
+        self.assertEqual(actual.ids, expected.ids)
+        for id1 in actual.ids:
+            for id2 in actual.ids:
+                npt.assert_almost_equal(actual[id1, id2], expected[id1, id2])
+
     def test_parallel_beta(self):
         t = Table(np.array([[0, 1, 3], [1, 1, 2]]),
                   ['O1', 'O2'],


### PR DESCRIPTION
This PR just adds another non-phylogenetic metric, Jensen Shannon distance, to the set of non_phylogenetic_metrics. It is one of those additional metrics implemented in [scipy.spatial.distance.pdist](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.pdist.html) which can be passed to skbio.diversity. 