### PR TITLE
Transition alpha_phylogenetic_alt to alpha_phylogenetic

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - psutil
     - natsort
     - biom-format >=2.1.5,<2.2.0
-    - unifrac >=0.9.2,<0.10.0
+    - unifrac >=0.10.0
     - qiime2 {{ release }}.*
     - q2templates {{ release }}.*
     - q2-types {{ release }}.*

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._alpha import (alpha, alpha_phylogenetic, alpha_phylogenetic_alt,
+from ._alpha import (alpha, alpha_phylogenetic,
                      alpha_group_significance, alpha_correlation,
                      alpha_rarefaction)
 from ._beta import (beta, beta_phylogenetic, bioenv,
@@ -24,8 +24,8 @@ del get_versions
 
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha',
-           'alpha_phylogenetic', 'alpha_phylogenetic_alt',
-           'pcoa', 'pcoa_biplot', 'alpha_group_significance', 'bioenv',
+           'alpha_phylogenetic', 'pcoa', 'pcoa_biplot',
+           'alpha_group_significance', 'bioenv',
            'beta_group_significance', 'alpha_correlation',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',

--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -6,7 +6,8 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from ._alpha import (alpha, alpha_phylogenetic,
+from ._alpha import (alpha, alpha_phylogenetic, alpha_phylogenetic_alt,
+                     alpha_phylogenetic_old,
                      alpha_group_significance, alpha_correlation,
                      alpha_rarefaction)
 from ._beta import (beta, beta_phylogenetic, bioenv,
@@ -24,8 +25,9 @@ del get_versions
 
 
 __all__ = ['beta', 'beta_phylogenetic', 'alpha',
-           'alpha_phylogenetic', 'pcoa', 'pcoa_biplot',
-           'alpha_group_significance', 'bioenv',
+           'alpha_phylogenetic', 'alpha_phylogenetic_alt',
+           'alpha_phylogenetic_old',
+           'pcoa', 'pcoa_biplot', 'alpha_group_significance', 'bioenv',
            'beta_group_significance', 'alpha_correlation',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',

--- a/q2_diversity/_alpha/__init__.py
+++ b/q2_diversity/_alpha/__init__.py
@@ -8,8 +8,7 @@
 
 
 from ._method import (alpha, alpha_phylogenetic, phylogenetic_metrics,
-                      non_phylogenetic_metrics,
-                      )
+                      non_phylogenetic_metrics)
 from ._visualizer import (alpha_group_significance, alpha_correlation,
                           alpha_rarefaction,
                           alpha_rarefaction_supported_metrics)

--- a/q2_diversity/_alpha/__init__.py
+++ b/q2_diversity/_alpha/__init__.py
@@ -7,13 +7,15 @@
 # ----------------------------------------------------------------------------
 
 
-from ._method import (alpha, alpha_phylogenetic, phylogenetic_metrics,
-                      non_phylogenetic_metrics)
+from ._method import (alpha, alpha_phylogenetic, alpha_phylogenetic_alt,
+                      alpha_phylogenetic_old,
+                      phylogenetic_metrics, non_phylogenetic_metrics)
 from ._visualizer import (alpha_group_significance, alpha_correlation,
                           alpha_rarefaction,
                           alpha_rarefaction_supported_metrics)
 
-__all__ = ['alpha', 'alpha_phylogenetic', 'alpha_group_significance',
-           'phylogenetic_metrics', 'non_phylogenetic_metrics',
-           'alpha_correlation', 'alpha_rarefaction',
-           'alpha_rarefaction_supported_metrics']
+__all__ = ['alpha', 'alpha_phylogenetic', 'alpha_phylogenetic_alt',
+           'alpha_phylogenetic_old',
+           'alpha_group_significance', 'phylogenetic_metrics',
+           'non_phylogenetic_metrics', 'alpha_correlation',
+           'alpha_rarefaction', 'alpha_rarefaction_supported_metrics']

--- a/q2_diversity/_alpha/__init__.py
+++ b/q2_diversity/_alpha/__init__.py
@@ -7,13 +7,14 @@
 # ----------------------------------------------------------------------------
 
 
-from ._method import (alpha, alpha_phylogenetic, alpha_phylogenetic_alt,
-                      phylogenetic_metrics, non_phylogenetic_metrics)
+from ._method import (alpha, alpha_phylogenetic, phylogenetic_metrics,
+                      non_phylogenetic_metrics,
+                      )
 from ._visualizer import (alpha_group_significance, alpha_correlation,
                           alpha_rarefaction,
                           alpha_rarefaction_supported_metrics)
 
-__all__ = ['alpha', 'alpha_phylogenetic', 'alpha_phylogenetic_alt',
-           'alpha_group_significance', 'phylogenetic_metrics',
-           'non_phylogenetic_metrics', 'alpha_correlation',
-           'alpha_rarefaction', 'alpha_rarefaction_supported_metrics']
+__all__ = ['alpha', 'alpha_phylogenetic', 'alpha_group_significance',
+           'phylogenetic_metrics', 'non_phylogenetic_metrics',
+           'alpha_correlation', 'alpha_rarefaction',
+           'alpha_rarefaction_supported_metrics']

--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -17,11 +17,8 @@ from q2_types.tree import NewickFormat
 
 # We should consider moving these functions to scikit-bio. They're part of
 # the private API here for now.
+
 def phylogenetic_metrics():
-    return {'faith_pd'}
-
-
-def phylogenetic_metrics_alt():
     return {'faith_pd': unifrac.faith_pd}
 
 
@@ -35,35 +32,9 @@ def non_phylogenetic_metrics():
             'lladser_pe', 'lladser_ci'}
 
 
-def alpha_phylogenetic(table: biom.Table, phylogeny: skbio.TreeNode,
+def alpha_phylogenetic(table: BIOMV210Format, phylogeny: NewickFormat,
                        metric: str) -> pd.Series:
-    if metric not in phylogenetic_metrics():
-        raise ValueError("Unknown phylogenetic metric: %s" % metric)
-    if table.is_empty():
-        raise ValueError("The provided table object is empty")
-
-    counts = table.matrix_data.toarray().astype(int).T
-    sample_ids = table.ids(axis='sample')
-    feature_ids = table.ids(axis='observation')
-
-    try:
-        result = skbio.diversity.alpha_diversity(metric=metric,
-                                                 counts=counts,
-                                                 ids=sample_ids,
-                                                 otu_ids=feature_ids,
-                                                 tree=phylogeny)
-    except skbio.tree.MissingNodeError as e:
-        message = str(e).replace('otu_ids', 'feature_ids')
-        message = message.replace('tree', 'phylogeny')
-        raise skbio.tree.MissingNodeError(message)
-
-    result.name = metric
-    return result
-
-
-def alpha_phylogenetic_alt(table: BIOMV210Format, phylogeny: NewickFormat,
-                           metric: str) -> pd.Series:
-    metrics = phylogenetic_metrics_alt()
+    metrics = phylogenetic_metrics()
     if metric not in metrics:
         raise ValueError("Unknown phylogenetic metric: %s" % metric)
 

--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -51,6 +51,37 @@ def alpha_phylogenetic(table: BIOMV210Format, phylogeny: NewickFormat,
     return result
 
 
+def alpha_phylogenetic_alt(table: BIOMV210Format, phylogeny: NewickFormat,
+                           metric: str) -> pd.Series:
+    return alpha_phylogenetic(table, phylogeny, metric)
+
+
+def alpha_phylogenetic_old(table: biom.Table, phylogeny: skbio.TreeNode,
+                           metric: str) -> pd.Series:
+    if metric not in phylogenetic_metrics():
+        raise ValueError("Unknown phylogenetic metric: %s" % metric)
+    if table.is_empty():
+        raise ValueError("The provided table object is empty")
+
+    counts = table.matrix_data.toarray().astype(int).T
+    sample_ids = table.ids(axis='sample')
+    feature_ids = table.ids(axis='observation')
+
+    try:
+        result = skbio.diversity.alpha_diversity(metric=metric,
+                                                 counts=counts,
+                                                 ids=sample_ids,
+                                                 otu_ids=feature_ids,
+                                                 tree=phylogeny)
+    except skbio.tree.MissingNodeError as e:
+        message = str(e).replace('otu_ids', 'feature_ids')
+        message = message.replace('tree', 'phylogeny')
+        raise skbio.tree.MissingNodeError(message)
+
+    result.name = metric
+    return result
+
+
 def alpha(table: biom.Table, metric: str) -> pd.Series:
     if metric not in non_phylogenetic_metrics():
         raise ValueError("Unknown metric: %s" % metric)

--- a/q2_diversity/_alpha/_method.py
+++ b/q2_diversity/_alpha/_method.py
@@ -19,6 +19,11 @@ from q2_types.tree import NewickFormat
 # the private API here for now.
 
 def phylogenetic_metrics():
+    return {'faith_pd'}
+
+
+# must contain an entry for every metric in phylogenetic_metrics
+def _phylogenetic_functions():
     return {'faith_pd': unifrac.faith_pd}
 
 
@@ -38,7 +43,7 @@ def alpha_phylogenetic(table: BIOMV210Format, phylogeny: NewickFormat,
     if metric not in metrics:
         raise ValueError("Unknown phylogenetic metric: %s" % metric)
 
-    f = metrics[metric]
+    f = _phylogenetic_functions()[metric]
 
     result = f(str(table), str(phylogeny))
 

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -405,7 +405,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
 
 
 alpha_rarefaction_supported_metrics = ((non_phylogenetic_metrics()
-                                       | phylogenetic_metrics().keys())
+                                       | phylogenetic_metrics())
                                        - {'osd', 'lladser_ci', 'strong',
                                           'esty_ci', 'kempton_taylor_q',
                                           'chao1_ci'})

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -23,6 +23,8 @@ import biom
 import skbio
 import itertools
 from q2_feature_table import rarefy
+from q2_types.feature_table import BIOMV210Format
+from qiime2.plugin.util import transform
 
 from ._method import (non_phylogenetic_metrics, phylogenetic_metrics,
                       alpha, alpha_phylogenetic)
@@ -293,6 +295,8 @@ def _compute_rarefaction_data(feature_table, min_depth, max_depth, steps,
         rt = rarefy(feature_table, d)
         for m in metrics:
             if m in phylogenetic_metrics():
+                rt = transform(rt, to_type=BIOMV210Format,
+                               from_type=biom.Table)
                 vector = alpha_phylogenetic(table=rt, metric=m,
                                             phylogeny=phylogeny)
             else:

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -296,9 +296,11 @@ def _compute_rarefaction_data(feature_table, min_depth, max_depth, steps,
         rt = rarefy(feature_table, d)
         for m in metrics:
             if m in phylogenetic_metrics():
-                rt = transform(rt, to_type=BIOMV210Format,
-                               from_type=biom.Table)
-                vector = alpha_phylogenetic(table=rt, metric=m,
+                # need a new rarefied table here in case a phylogenetic
+                # metric comes before a non-phylogenetic metric
+                rt_p = transform(rt, to_type=BIOMV210Format,
+                                 from_type=biom.Table)
+                vector = alpha_phylogenetic(table=rt_p, metric=m,
                                             phylogeny=phylogeny)
             else:
                 vector = alpha(table=rt, metric=m)

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -20,7 +20,6 @@ import qiime2
 from statsmodels.sandbox.stats.multicomp import multipletests
 import q2templates
 import biom
-import skbio
 import itertools
 from q2_feature_table import rarefy
 from q2_types.feature_table import BIOMV210Format

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -25,6 +25,7 @@ import itertools
 from q2_feature_table import rarefy
 from q2_types.feature_table import BIOMV210Format
 from qiime2.plugin.util import transform
+from q2_types.tree import NewickFormat
 
 from ._method import (non_phylogenetic_metrics, phylogenetic_metrics,
                       alpha, alpha_phylogenetic)
@@ -306,7 +307,7 @@ def _compute_rarefaction_data(feature_table, min_depth, max_depth, steps,
 
 
 def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
-                      phylogeny: skbio.TreeNode = None, metrics: set = None,
+                      phylogeny: NewickFormat = None, metrics: set = None,
                       metadata: qiime2.Metadata = None, min_depth: int = 1,
                       steps: int = 10, iterations: int = 10) -> None:
 

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -405,7 +405,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
 
 
 alpha_rarefaction_supported_metrics = ((non_phylogenetic_metrics()
-                                       | phylogenetic_metrics())
+                                       | phylogenetic_metrics().keys())
                                        - {'osd', 'lladser_ci', 'strong',
                                           'esty_ci', 'kempton_taylor_q',
                                           'chao1_ci'})

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -148,39 +148,6 @@ plugin.methods.register_function(
 )
 
 plugin.methods.register_function(
-    function=q2_diversity.alpha_phylogenetic,
-    inputs={'table': FeatureTable[Frequency],
-            'phylogeny': Phylogeny[Rooted]},
-    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},
-    outputs=[('alpha_diversity',
-              SampleData[AlphaDiversity] % Properties('phylogenetic'))],
-    input_descriptions={
-        'table': ('The feature table containing the samples for which alpha '
-                  'diversity should be computed.'),
-        'phylogeny': ('Phylogenetic tree containing tip identifiers that '
-                      'correspond to the feature identifiers in the table. '
-                      'This tree can contain tip ids that are not present in '
-                      'the table, but all feature ids in the table must be '
-                      'present in this tree.')
-    },
-    parameter_descriptions={
-        'metric': 'The alpha diversity metric to be computed.'
-    },
-    output_descriptions={
-        'alpha_diversity': 'Vector containing per-sample alpha diversities.'
-    },
-    name='Alpha diversity (phylogenetic) - alternative implementation',
-    description=("Computes a user-specified phylogenetic alpha diversity "
-                 "metric for all samples in a feature table. This "
-                 "implementation is recommended for large datasets, otherwise "
-                 "the results are identical to alpha_phylogenetic. \n\n"
-                 "This method is an implementation of the Stacked Faith "
-                 "Algorithm (manuscript in preparation)."),
-    citations=[
-        citations['faith1992conservation']]
-)
-
-plugin.methods.register_function(
     function=q2_diversity.alpha,
     inputs={'table': FeatureTable[Frequency]},
     parameters={'metric': Str % Choices(alpha.non_phylogenetic_metrics())},

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -142,10 +142,81 @@ plugin.methods.register_function(
     },
     name='Alpha diversity (phylogenetic)',
     description=("Computes a user-specified phylogenetic alpha diversity "
-                 "metric for all samples in a feature table."),
+                 "metric for all samples in a feature table. This "
+                 "implementation is recommended for large datasets, otherwise "
+                 "the results are identical to alpha_phylogenetic. \n\n"
+                 "This method is an implementation of the Stacked Faith "
+                 "Algorithm (manuscript in preparation)."),
     citations=[
         citations['faith1992conservation']]
 )
+
+
+plugin.methods.register_function(
+    function=q2_diversity.alpha_phylogenetic_alt,
+    inputs={'table': FeatureTable[Frequency],
+            'phylogeny': Phylogeny[Rooted]},
+    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},
+    outputs=[('alpha_diversity',
+              SampleData[AlphaDiversity] % Properties('phylogenetic'))],
+    input_descriptions={
+        'table': ('The feature table containing the samples for which alpha '
+                  'diversity should be computed.'),
+        'phylogeny': ('Phylogenetic tree containing tip identifiers that '
+                      'correspond to the feature identifiers in the table. '
+                      'This tree can contain tip ids that are not present in '
+                      'the table, but all feature ids in the table must be '
+                      'present in this tree.')
+    },
+    parameter_descriptions={
+        'metric': 'The alpha diversity metric to be computed.'
+    },
+    output_descriptions={
+        'alpha_diversity': 'Vector containing per-sample alpha diversities.'
+    },
+    name='Alpha diversity (phylogenetic) - alternative implementation',
+    description=("Computes a user-specified phylogenetic alpha diversity "
+                 "metric for all samples in a feature table. This "
+                 "implementation is recommended for large datasets, otherwise "
+                 "the results are identical to alpha_phylogenetic. \n\n"
+                 "This method is an implementation of the Stacked Faith "
+                 "Algorithm (manuscript in preparation)."),
+    citations=[
+        citations['faith1992conservation']],
+    deprecated=True,
+)
+
+
+plugin.methods.register_function(
+    function=q2_diversity.alpha_phylogenetic_old,
+    inputs={'table': FeatureTable[Frequency],
+            'phylogeny': Phylogeny[Rooted]},
+    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},
+    outputs=[('alpha_diversity',
+              SampleData[AlphaDiversity] % Properties('phylogenetic'))],
+    input_descriptions={
+        'table': ('The feature table containing the samples for which alpha '
+                  'diversity should be computed.'),
+        'phylogeny': ('Phylogenetic tree containing tip identifiers that '
+                      'correspond to the feature identifiers in the table. '
+                      'This tree can contain tip ids that are not present in '
+                      'the table, but all feature ids in the table must be '
+                      'present in this tree.')
+    },
+    parameter_descriptions={
+        'metric': 'The alpha diversity metric to be computed.'
+    },
+    output_descriptions={
+        'alpha_diversity': 'Vector containing per-sample alpha diversities.'
+    },
+    name='Alpha diversity (phylogenetic)',
+    description=("Computes a user-specified phylogenetic alpha diversity "
+                 "metric for all samples in a feature table."),
+    citations=[
+        citations['faith1992conservation']],
+    deprecated=True,
+)
+
 
 plugin.methods.register_function(
     function=q2_diversity.alpha,

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -122,7 +122,7 @@ plugin.methods.register_function(
     function=q2_diversity.alpha_phylogenetic,
     inputs={'table': FeatureTable[Frequency],
             'phylogeny': Phylogeny[Rooted]},
-    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},
+    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics().keys())},
     outputs=[('alpha_diversity',
               SampleData[AlphaDiversity] % Properties('phylogenetic'))],
     input_descriptions={
@@ -148,7 +148,7 @@ plugin.methods.register_function(
 )
 
 plugin.methods.register_function(
-    function=q2_diversity.alpha_phylogenetic_alt,
+    function=q2_diversity.alpha_phylogenetic,
     inputs={'table': FeatureTable[Frequency],
             'phylogeny': Phylogeny[Rooted]},
     parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -122,7 +122,7 @@ plugin.methods.register_function(
     function=q2_diversity.alpha_phylogenetic,
     inputs={'table': FeatureTable[Frequency],
             'phylogeny': Phylogeny[Rooted]},
-    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics().keys())},
+    parameters={'metric': Str % Choices(alpha.phylogenetic_metrics())},
     outputs=[('alpha_diversity',
               SampleData[AlphaDiversity] % Properties('phylogenetic'))],
     input_descriptions={

--- a/q2_diversity/tests/test_alpha.py
+++ b/q2_diversity/tests/test_alpha.py
@@ -10,17 +10,15 @@ import os
 import tempfile
 import unittest
 
-import io
 import biom
-import skbio
 import qiime2
 from qiime2.plugin.testing import TestPluginBase
 import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
 
-from q2_diversity import (alpha, alpha_phylogenetic, alpha_correlation,
-                          alpha_phylogenetic_alt, alpha_group_significance)
+from q2_diversity import (alpha, alpha_correlation,
+                          alpha_phylogenetic, alpha_group_significance)
 
 
 class AlphaTests(TestPluginBase):
@@ -57,63 +55,12 @@ class AlphaTests(TestPluginBase):
         with self.assertRaisesRegex(ValueError, "empty"):
             alpha(table=t, metric='observed_otus')
 
-    def test_alpha_phylogenetic(self):
-        t = biom.Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                       ['O1', 'O2'],
-                       ['S1', 'S2', 'S3'])
-        tree = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
-        actual = alpha_phylogenetic(table=t, phylogeny=tree, metric='faith_pd')
-        # expected computed with skbio.diversity.alpha_diversity
-        expected = pd.Series({'S1': 0.75, 'S2': 1.0, 'S3': 1.0},
-                             name='faith_pd')
-        pdt.assert_series_equal(actual, expected)
-
-    def test_alpha_phylogenetic_non_phylo_metric(self):
-        t = biom.Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                       ['O1', 'O2'],
-                       ['S1', 'S2', 'S3'])
-        tree = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
-        with self.assertRaisesRegex(ValueError, 'Unknown phylogenetic metric'):
-            alpha_phylogenetic(table=t, phylogeny=tree,
-                               metric='observed_otus')
-
-    def test_alpha_phylogenetic_unknown_metric(self):
-        t = biom.Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                       ['O1', 'O2'],
-                       ['S1', 'S2', 'S3'])
-        tree = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
-        with self.assertRaisesRegex(ValueError, 'Unknown phylogenetic metric'):
-            alpha_phylogenetic(table=t, phylogeny=tree, metric='not-a-metric')
-
-    def test_alpha_phylogenetic_skbio_error_rewriting(self):
-        t = biom.Table(np.array([[0, 1, 3], [1, 1, 2]]),
-                       ['O1', 'O2'],
-                       ['S1', 'S2', 'S3'])
-        tree = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25):0.25, O3:0.75)root;'))
-        # Verify through regex that there is a ``feature_ids`` substring
-        # followed by a ``phylogeny``
-        with self.assertRaisesRegex(skbio.tree.MissingNodeError,
-                                    'feature_ids.*phylogeny'):
-            alpha_phylogenetic(table=t, phylogeny=tree, metric='faith_pd')
-
-    def test_alpha_phylogenetic_empty_table(self):
-        t = biom.Table(np.array([]), [], [])
-        tree = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25):0.25, O3:0.75)root;'))
-
-        with self.assertRaisesRegex(ValueError, "empty"):
-            alpha_phylogenetic(table=t, phylogeny=tree, metric='faith_pd')
-
     def test_alpha_phylogenetic_alt(self):
         table = self.get_data_path('two_feature_table.biom')
         tree = self.get_data_path('three_feature.tree')
-        actual = alpha_phylogenetic_alt(table=table,
-                                        phylogeny=tree,
-                                        metric='faith_pd')
+        actual = alpha_phylogenetic(table=table,
+                                    phylogeny=tree,
+                                    metric='faith_pd')
         # expected computed with skbio.diversity.alpha_diversity
         expected = pd.Series({'S1': 0.75, 'S2': 1.0, 'S3': 1.0},
                              name='faith_pd')
@@ -123,17 +70,17 @@ class AlphaTests(TestPluginBase):
         table = self.get_data_path('two_feature_table.biom')
         tree = self.get_data_path('three_feature.tree')
         with self.assertRaisesRegex(ValueError, 'Unknown phylogenetic metric'):
-            alpha_phylogenetic_alt(table=table,
-                                   phylogeny=tree,
-                                   metric='observed_otus')
+            alpha_phylogenetic(table=table,
+                               phylogeny=tree,
+                               metric='observed_otus')
 
     def test_alpha_phylogenetic_alt_unknown_metric(self):
         table = self.get_data_path('two_feature_table.biom')
         tree = self.get_data_path('three_feature.tree')
         with self.assertRaisesRegex(ValueError, 'Unknown phylogenetic metric'):
-            alpha_phylogenetic_alt(table=table,
-                                   phylogeny=tree,
-                                   metric='not-a-metric')
+            alpha_phylogenetic(table=table,
+                               phylogeny=tree,
+                               metric='not-a-metric')
 
     def test_alpha_phylogenetic_alt_skbio_error_rewriting(self):
         table = self.get_data_path('two_feature_table.biom')
@@ -141,18 +88,18 @@ class AlphaTests(TestPluginBase):
         with self.assertRaisesRegex(ValueError, "The table does not "
                                     "appear to be completely represented "
                                     "by the phylogeny."):
-            alpha_phylogenetic_alt(table=table,
-                                   phylogeny=tree,
-                                   metric='faith_pd')
+            alpha_phylogenetic(table=table,
+                               phylogeny=tree,
+                               metric='faith_pd')
 
     def test_alpha_phylogenetic_alt_empty_table(self):
         table = self.get_data_path('empty.biom')
         tree = self.get_data_path('three_feature.tree')
 
         with self.assertRaisesRegex(ValueError, "empty"):
-            alpha_phylogenetic_alt(table=table,
-                                   phylogeny=tree,
-                                   metric='faith_pd')
+            alpha_phylogenetic(table=table,
+                               phylogeny=tree,
+                               metric='faith_pd')
 
 
 class AlphaCorrelationTests(unittest.TestCase):

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -17,6 +17,8 @@ import pandas.testing as pdt
 import qiime2
 import skbio
 import pandas as pd
+from qiime2.plugin.util import transform
+from q2_types.tree import NewickFormat
 from q2_diversity import alpha_rarefaction
 from q2_diversity._alpha._visualizer import (
     _compute_rarefaction_data, _compute_summary, _reindex_with_metadata,
@@ -24,6 +26,12 @@ from q2_diversity._alpha._visualizer import (
 
 
 class AlphaRarefactionTests(unittest.TestCase):
+
+    @staticmethod
+    def _to_newick(tree: skbio.TreeNode):
+        return transform(tree, from_type=skbio.TreeNode,
+                         to_type=NewickFormat)
+
     def test_alpha_rarefaction_without_metadata(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],
@@ -107,8 +115,8 @@ class AlphaRarefactionTests(unittest.TestCase):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],
                        ['S1', 'S2', 'S3'])
-        p = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
+        p = self._to_newick(skbio.TreeNode.read(io.StringIO(
+            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;')))
 
         with tempfile.TemporaryDirectory() as output_dir:
             alpha_rarefaction(output_dir, t, max_depth=200, phylogeny=p)
@@ -124,8 +132,8 @@ class AlphaRarefactionTests(unittest.TestCase):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],
                        ['S1', 'S2', 'S3'])
-        p = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
+        p = self._to_newick(skbio.TreeNode.read(io.StringIO(
+            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;')))
         md = qiime2.Metadata(
             pd.DataFrame({'pet': ['russ', 'milo', 'peanut']},
                          index=pd.Index(['S1', 'S2', 'S3'], name='id')))
@@ -237,6 +245,11 @@ class ComputeRarefactionDataTests(unittest.TestCase):
     def setUp(self):
         np.random.seed(0)
 
+    @staticmethod
+    def _to_newick(tree: skbio.TreeNode):
+        return transform(tree, from_type=skbio.TreeNode,
+                         to_type=NewickFormat)
+
     def test_observed_otus(self):
         t = biom.Table(np.array([[150, 100, 100], [50, 100, 100]]),
                        ['O1', 'O2'],
@@ -261,8 +274,8 @@ class ComputeRarefactionDataTests(unittest.TestCase):
         t = biom.Table(np.array([[150, 100, 100], [50, 100, 100]]),
                        ['O1', 'O2'],
                        ['S1', 'S2', 'S3'])
-        p = skbio.TreeNode.read(io.StringIO(
-            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;'))
+        p = self._to_newick(skbio.TreeNode.read(io.StringIO(
+            '((O1:0.25, O2:0.50):0.25, O3:0.75)root;')))
 
         obs = _compute_rarefaction_data(feature_table=t,
                                         min_depth=1,


### PR DESCRIPTION
This PR is to transition the `alpha_phylogenetic_alt` method to `alpha_phylogenetic` as the main method for computing Faith's PD with `q2-diversity`. As a reminder, the implementation for the current `alpha_phylogenetic_alt` yields speed improvements and a memory reduction of several orders of magnitude. See [here](https://github.com/biocore/unifrac/pull/65) for more details.
