### PR TITLE
BUG: Corrects typo in mantel skbio URL

### DIFF
--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -655,7 +655,7 @@ plugin.visualizers.register_function(
                 'the same; the distance matrices will be reordered before '
                 'applying the Mantel test.\n\nSee the scikit-bio docs for '
                 'more details about the Mantel test:\n\n'
-                'http://scikit-bio.org/docs/latest/generated/generated/'
+                'http://scikit-bio.org/docs/latest/generated/'
                 'skbio.stats.distance.mantel.html',
     input_descriptions={
         'dm1': 'Matrix of distances between pairs of samples.',

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -656,7 +656,7 @@ plugin.visualizers.register_function(
                 'applying the Mantel test.\n\nSee the scikit-bio docs for '
                 'more details about the Mantel test:\n\n'
                 'http://scikit-bio.org/docs/latest/generated/'
-                'skbio.stats.distance.mantel.html',
+                'skbio.stats.distance.mantel',
     input_descriptions={
         'dm1': 'Matrix of distances between pairs of samples.',
         'dm2': 'Matrix of distances between pairs of samples.'


### PR DESCRIPTION
Bad URL was causing 404 errors. This PR removes duplicated `generated` to align with correct address.