### PR TITLE
MAINT: Change depth column name

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -286,8 +286,9 @@ def _compute_rarefaction_data(feature_table, min_depth, max_depth, steps,
     iter_range = range(1, iterations + 1)
 
     rows = feature_table.ids(axis='sample')
-    cols = pd.MultiIndex.from_product([list(depth_range), list(iter_range)],
-                                      names=['depth', 'iter'])
+    cols = pd.MultiIndex.from_product(
+        [list(depth_range), list(iter_range)],
+        names=['_alpha_rarefaction_depth_column_', 'iter'])
     data = {k: pd.DataFrame(np.NaN, index=rows, columns=cols)
             for k in metrics}
 
@@ -391,8 +392,9 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
                 filenames.append(jsonp_filename)
 
         with open(os.path.join(output_dir, filename), 'w') as fh:
-            data.columns = ['depth-%d_iter-%d' % (t[0], t[1])
-                            for t in data.columns.values]
+            data.columns = [
+                '_alpha_rarefaction_depth_column_-%d_iter-%d' % (t[0], t[1])
+                for t in data.columns.values]
             if metadata is not None:
                 data = data.join(metadata.to_dataframe(), how='left')
             data.to_csv(fh, index_label=['sample-id'])

--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -393,7 +393,7 @@ def alpha_rarefaction(output_dir: str, table: biom.Table, max_depth: int,
 
         with open(os.path.join(output_dir, filename), 'w') as fh:
             data.columns = [
-                '_alpha_rarefaction_depth_column_-%d_iter-%d' % (t[0], t[1])
+                'depth-%d_iter-%d' % (t[0], t[1])
                 for t in data.columns.values]
             if metadata is not None:
                 data = data.join(metadata.to_dataframe(), how='left')

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/src/data.js
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/src/data.js
@@ -8,7 +8,7 @@ export function setupData(data, metric) {
   let maxY = 0;
   let minSubY = Infinity;
   let maxSubY = 0;
-  const depthIndex = data.columns.indexOf('depth');
+  const depthIndex = data.columns.indexOf('_alpha_rarefaction_depth_column_');
   const lowerWhiskerIndex = data.columns.indexOf('9%');
   const upperWhiskerIndex = data.columns.indexOf('91%');
   const countIndex = data.columns.indexOf('count');

--- a/q2_diversity/_alpha/alpha_rarefaction_assets/src/render.js
+++ b/q2_diversity/_alpha/alpha_rarefaction_assets/src/render.js
@@ -20,7 +20,7 @@ function renderPlot(svg, data, x, y, subY, column, legend, legendTitle) {
   const subChart = svg.select('#subChart');
   const legendBox = select(legend.node().parentNode);
 
-  const depthIndex = data.data.columns.indexOf('depth');
+  const depthIndex = data.data.columns.indexOf('_alpha_rarefaction_depth_column_');
   const lowerWhiskerIndex = data.data.columns.indexOf('9%');
   const lowerBoxIndex = data.data.columns.indexOf('25%');
   const medianIndex = data.data.columns.indexOf('50%');

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -264,7 +264,7 @@ class ComputeRarefactionDataTests(unittest.TestCase):
 
         exp_ind = pd.MultiIndex.from_product(
             [[1, 200], [1]],
-            names=['depth', 'iter'])
+            names=['_alpha_rarefaction_depth_column_', 'iter'])
         exp = pd.DataFrame(data=[[1, 2], [1, 2], [1, 2]],
                            columns=exp_ind,
                            index=['S1', 'S2', 'S3'])
@@ -301,7 +301,7 @@ class ComputeRarefactionDataTests(unittest.TestCase):
 
         exp_ind = pd.MultiIndex.from_product(
             [[1, 200], [1]],
-            names=['depth', 'iter'])
+            names=['_alpha_rarefaction_depth_column_', 'iter'])
         exp = pd.DataFrame(data=[[1, 2], [1, 2], [1, 2]],
                            columns=exp_ind,
                            index=['S1', 'S2', 'S3'])

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -111,6 +111,22 @@ class AlphaRarefactionTests(unittest.TestCase):
             self.assertFalse(
                 os.path.exists(os.path.join(output_dir, 'shannon-bar.jsonp')))
 
+    def test_alpha_rarefaction_with_depth_column_in_metadata(self):
+        t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
+                       ['O1', 'O2'],
+                       ['S1', 'S2', 'S3'])
+        md = qiime2.Metadata(
+            pd.DataFrame({'depth': ['1', '2', '3']},
+                         index=pd.Index(['S1', 'S2', 'S3'], name='id')))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_rarefaction(output_dir, t, max_depth=200, metadata=md)
+            index_fp = os.path.join(output_dir, 'index.html')
+            self.assertTrue(os.path.exists(index_fp))
+            with open(index_fp) as index_fh:
+                index_content = index_fh.read()
+            self.assertTrue('observed_otus' in index_content)
+            self.assertTrue('shannon' in index_content)
+
     def test_alpha_rarefaction_with_phylogeny(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],


### PR DESCRIPTION
Closes #279. Changes name from `depth` to `_alpha_rarefaction_depth_column_` to mitigate overlap risk.
