### PR TITLE
imp: adonis - tighten scope of nan-checking; tests

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -363,11 +363,11 @@ def adonis(output_dir: str,
     terms = ModelDesc.from_formula(formula)
     for t in terms.rhs_termlist:
         for i in t.factors:
-            metadata.get_column(i.name())
-
-    metadata_df = metadata.to_dataframe()
-    if metadata_df.isnull().values.any():
-        raise ValueError("Adonis cannot run with NaNs in metadata.")
+            column = metadata.get_column(i.name())
+            if column.has_missing_values():
+                raise ValueError('adonis requires metadata columns with no '
+                                 'NaN values (missing values in column `%s`.)'
+                                 % (column.name, ))
 
     # Run adonis
     results_fp = os.path.join(output_dir, 'adonis.tsv')

--- a/q2_diversity/tests/test_adonis.py
+++ b/q2_diversity/tests/test_adonis.py
@@ -13,6 +13,7 @@ import tempfile
 import skbio
 import pandas as pd
 import qiime2
+from qiime2.util import redirected_stdio
 import numpy as np
 from q2_diversity import adonis
 import pandas.util.testing as pdt
@@ -91,6 +92,23 @@ class AdonisTests(TestPluginBase):
                            name='#SampleID')))
         with tempfile.TemporaryDirectory() as temp_dir_name:
             adonis(temp_dir_name, self.dm, md, 'letter+number')
+
+    def test_nans_in_formula_column(self):
+        md = qiime2.Metadata(pd.DataFrame(
+            [[1, 'a'], [1, 'b'], [np.nan, 'b']], columns=['number', 'letter'],
+            index=pd.Index(['sample1', 'sample2', 'sample3'], name='id')))
+        with redirected_stdio(stderr=os.devnull):
+            with self.assertRaisesRegex(ValueError, "no NaN values.*`number`"):
+                with tempfile.TemporaryDirectory() as temp_dir_name:
+                    adonis(temp_dir_name, self.dm, md, 'letter+number')
+
+    def test_nans_in_unused_column(self):
+        md = qiime2.Metadata(pd.DataFrame(
+            [[1, 'a'], [1, 'b'], [np.nan, 'b']], columns=['number', 'letter'],
+            index=pd.Index(['sample1', 'sample2', 'sample3'], name='id')))
+        with redirected_stdio(stderr=os.devnull):
+            with tempfile.TemporaryDirectory() as temp_dir_name:
+                adonis(temp_dir_name, self.dm, md, 'letter+letter')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a follow-up PR for https://github.com/qiime2/q2-diversity/pull/282

cc @collin-le & @nbokulich

---

This PR tightens up the NaN checking to _only the columns used in the formula_, rather than raising an error on _any_ column, even if it isn't used.

This changeset also adds a few quick unit tests to exercise this behavior.