### PR TITLE
imp: m2 fmt validation and metadata-compatible

### DIFF
--- a/q2_diversity/_format.py
+++ b/q2_diversity/_format.py
@@ -7,11 +7,28 @@
 # ----------------------------------------------------------------------------
 
 import qiime2.plugin.model as model
+from qiime2.plugin import ValidationError
+import qiime2
 
 
 class ProcrustesM2StatisticFmt(model.TextFileFormat):
-    def validate(*args):
-        pass
+    METADATA_COLUMNS = {
+        'true M^2 value',
+        'p-value for true M^2 value',
+        'number of Monte Carlo trials',
+    }
+
+    def validate(self, level):
+        try:
+            md = qiime2.Metadata.load(str(self))
+        except qiime2.metadata.MetadataFileError as md_exc:
+            raise ValidationError(md_exc) from md_exc
+
+        for column in sorted(self.METADATA_COLUMNS):
+            try:
+                md.get_column(column)
+            except ValueError as md_exc:
+                raise ValidationError(md_exc) from md_exc
 
 
 ProcrustesM2StatDFmt = model.SingleFileDirectoryFormat(

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -83,10 +83,8 @@ def _procrustes_monte_carlo(reference: np.ndarray,
     2: number of Monte Carlo trials done in simulation
     '''
 
-    df = pd.DataFrame()
     rng = default_rng()
 
-    results = []
     trials_below_m2 = 0
 
     for i in range(trials):
@@ -102,9 +100,10 @@ def _procrustes_monte_carlo(reference: np.ndarray,
             trials_below_m2 += 1
 
     p_val = trials_below_m2 / trials
-    results.append(true_m2)
-    results.append(p_val)
-    results.append(trials)
-    df['Procrustes Results'] = results
+
+    df = pd.DataFrame({'true M^2 value': [true_m2],
+                       'p-value for true M^2 value': [p_val],
+                       'number of Monte Carlo trials': [trials]},
+                      index=pd.Index(['results'], name='id'))
 
     return df

--- a/q2_diversity/_transformer.py
+++ b/q2_diversity/_transformer.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import pandas as pd
+import qiime2
 
 from .plugin_setup import plugin
 from ._format import ProcrustesM2StatisticFmt
@@ -15,10 +16,15 @@ from ._format import ProcrustesM2StatisticFmt
 @plugin.register_transformer
 def _1(data: pd.DataFrame) -> ProcrustesM2StatisticFmt:
     ff = ProcrustesM2StatisticFmt()
-    data.to_csv(str(ff))
+    qiime2.Metadata(data).save(str(ff))
     return ff
 
 
 @plugin.register_transformer
 def _2(ff: ProcrustesM2StatisticFmt) -> pd.DataFrame:
-    return pd.read_csv(str(ff), index_col=0)
+    return qiime2.Metadata.load(str(ff)).to_dataframe()
+
+
+@plugin.register_transformer
+def _3(ff: ProcrustesM2StatisticFmt) -> qiime2.Metadata:
+    return qiime2.Metadata.load(str(ff))

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -268,8 +268,8 @@ plugin.methods.register_function(
                                  'ordination matrix.',
         'transformed_other': 'A normalized and fitted version of the "other" '
                              'ordination matrix.',
-        'disparity_results': 'The sum of the squares of the pointwise     '
-                             'differences between the two input datasets &'
+        'disparity_results': 'The sum of the squares of the pointwise '
+                             'differences between the two input datasets & '
                              'its p value.'},
     name='Procrustes Analysis',
     description='Fit two ordination matrices with Procrustes analysis'

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -85,8 +85,8 @@ class PCoATests(unittest.TestCase):
     def test_procrustes(self):
         ref, other, m2_results = procrustes_analysis(self.reference,
                                                      self.other)
-        true_m2 = m2_results['Procrustes Results'][0]
-        true_p_value = m2_results['Procrustes Results'][1]
+        true_m2 = m2_results['true M^2 value'][0]
+        true_p_value = m2_results['p-value for true M^2 value'][0]
 
         skbio.util.assert_ordination_results_equal(ref, self.expected_ref)
         skbio.util.assert_ordination_results_equal(other, self.expected_other)


### PR DESCRIPTION
@ahdilmore - this PR tweaks the format of the M2 stats a little bit, to make it compatible with QIIME 2 Metadata - this will allow users to "view" the output stats using q2-metadata's `tabulate` visualizer. Basically I transposed the Pandas table, and made the file format into a TSV. I added a new transformer to facilitate viewing as Metadata, and also added some code for validating the format. Would you mind reviewing this and letting me know what you think? Thanks so much! 🦖 

PS - I also cleaned up some parameter description formatting and tacked it into this changeset.