### PR TITLE
ENH: Multiple changes and enhancements

### DIFF
--- a/q2_diversity/_format.py
+++ b/q2_diversity/_format.py
@@ -15,7 +15,7 @@ class ProcrustesM2StatisticFmt(model.TextFileFormat):
     METADATA_COLUMNS = {
         'true M^2 value',
         'p-value for true M^2 value',
-        'number of Monte Carlo trials',
+        'number of Monte Carlo permutations',
     }
 
     def validate(self, level):

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -86,6 +86,9 @@ def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
 
     trials_below_m2 = 0
 
+    if permutations == 'disable':
+        permutations = 0
+
     for i in range(permutations):
 
         # shuffle rows in np array
@@ -98,7 +101,7 @@ def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
         if m2 < true_m2:
             trials_below_m2 += 1
 
-    if permutations == 'disable':
+    if permutations == 0:
         p_val = np.nan
     else:
         # mimic the behaviour in scikit-bio's permutation-based tests and avoid

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -98,7 +98,7 @@ def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
         if m2 < true_m2:
             trials_below_m2 += 1
 
-    if permutations == 0:
+    if permutations == 'disable':
         p_val = np.nan
     else:
         # mimic the behaviour in scikit-bio's permutation-based tests and avoid

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -15,9 +15,10 @@ from numpy.random import default_rng
 
 
 def procrustes_analysis(reference: OrdinationResults, other: OrdinationResults,
-                        dimensions: int = 5) -> (OrdinationResults,
-                                                 OrdinationResults,
-                                                 pd.DataFrame):
+                        dimensions: int = 5,
+                        permutations: int = 999) -> (OrdinationResults,
+                                                     OrdinationResults,
+                                                     pd.DataFrame):
 
     if reference.samples.shape != other.samples.shape:
         raise ValueError('The matrices cannot be fitted unless they have the '
@@ -47,8 +48,7 @@ def procrustes_analysis(reference: OrdinationResults, other: OrdinationResults,
 
     info = _procrustes_monte_carlo(reference.samples.values[:, :dimensions],
                                    other.samples.values[:, :dimensions],
-                                   m2,
-                                   1000)
+                                   m2, permutations)
 
     out1 = OrdinationResults(
             short_method_name=reference.short_method_name,
@@ -73,22 +73,20 @@ def procrustes_analysis(reference: OrdinationResults, other: OrdinationResults,
     return out1, out2, info
 
 
-def _procrustes_monte_carlo(reference: np.ndarray,
-                            other: np.ndarray,
-                            true_m2,
-                            trials=1000) -> (pd.DataFrame):
+def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
+                            true_m2, permutations) -> (pd.DataFrame):
     '''
     Outputs a dataframe containing:
     0: True M^2 value
     1: p-value for true M^2 value
-    2: number of Monte Carlo trials done in simulation
+    2: number of Monte Carlo permutations done in simulation
     '''
 
     rng = default_rng()
 
     trials_below_m2 = 0
 
-    for i in range(trials):
+    for i in range(permutations):
 
         # shuffle rows in np array
         rng.shuffle(other)
@@ -100,11 +98,16 @@ def _procrustes_monte_carlo(reference: np.ndarray,
         if m2 < true_m2:
             trials_below_m2 += 1
 
-    p_val = trials_below_m2 / trials
+    if permutations == 0:
+        p_val = np.nan
+    else:
+        # mimic the behaviour in scikit-bio's permutation-based tests and avoid
+        # returning p-values equal to zero
+        p_val = (trials_below_m2 + 1) / (permutations + 1)
 
     df = pd.DataFrame({'true M^2 value': [true_m2],
                        'p-value for true M^2 value': [p_val],
-                       'number of Monte Carlo trials': [trials]},
+                       'number of Monte Carlo permutations': [permutations]},
                       index=pd.Index(['results'], name='id'))
 
     return df

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -253,7 +253,7 @@ plugin.methods.register_function(
     inputs={'reference': PCoAResults, 'other': PCoAResults},
     parameters={
         'dimensions': Int % Range(1, None),
-        'permutations': Int % Range(0, None)
+        'permutations': Int % Range(1, None) | Str % Choices('disable')
     },
     outputs=[
         ('transformed_reference', PCoAResults),
@@ -269,7 +269,7 @@ plugin.methods.register_function(
         'dimensions': ('The number of dimensions to use when fitting the two '
                        'matrices'),
         'permutations': 'The number of permutations to be run when computing '
-                        'p-values. Supplying a value of zero will disable '
+                        'p-values. Supplying a value of `disable` will disable '
                         'permutation testing and p-values will not be '
                         'calculated (this results in *much* quicker execution '
                         'time if p-values are not desired).',

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -251,7 +251,10 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=q2_diversity.procrustes_analysis,
     inputs={'reference': PCoAResults, 'other': PCoAResults},
-    parameters={'dimensions': Int % Range(1, None)},
+    parameters={
+        'dimensions': Int % Range(1, None),
+        'permutations': Int % Range(0, None)
+    },
     outputs=[
         ('transformed_reference', PCoAResults),
         ('transformed_other', PCoAResults),
@@ -260,9 +263,18 @@ plugin.methods.register_function(
     input_descriptions={
         'reference': ('The ordination matrix to which data is fitted to.'),
         'other': ("The ordination matrix that's fitted to the reference "
-                  "ordination.")
+                  "ordination."),
     },
-    parameter_descriptions={},
+    parameter_descriptions={
+        'dimensions': ('The number of dimensions to use when fitting the two '
+                       'matrices'),
+        'permutations': 'The number of permutations to be run when computing '
+                        'p-values. Supplying a value of zero will disable '
+                        'permutation testing and p-values will not be '
+                        'calculated (this results in *much* quicker execution '
+                        'time if p-values are not desired).',
+
+    },
     output_descriptions={
         'transformed_reference': 'A normalized version of the "reference" '
                                  'ordination matrix.',

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -269,8 +269,8 @@ plugin.methods.register_function(
         'dimensions': ('The number of dimensions to use when fitting the two '
                        'matrices'),
         'permutations': 'The number of permutations to be run when computing '
-                        'p-values. Supplying a value of `disable` will disable '
-                        'permutation testing and p-values will not be '
+                        'p-values. Supplying a value of `disable` will disable'
+                        ' permutation testing and p-values will not be '
                         'calculated (this results in *much* quicker execution '
                         'time if p-values are not desired).',
 

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -138,7 +138,7 @@ class PCoATests(unittest.TestCase):
     def test_zero_permutations_nan_pvalue(self):
         ref, other, m2_results = procrustes_analysis(self.reference,
                                                      self.other,
-                                                     permutations=0)
+                                                     permutations='disable')
         true_m2 = m2_results['true M^2 value'][0]
         true_p_value = m2_results['p-value for true M^2 value'][0]
 

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -79,6 +79,21 @@ class PCoATests(unittest.TestCase):
                 samples_df.copy(),
                 proportion_explained=proportion_explained[:5].copy())
 
+        noise = [
+            [0.04988341, -0.03234447, 0.03177641, -0.03507789, -0.13564394],
+            [0.09117347, -0.08318546, -0.02249053, -0.01597601, -0.10901541],
+            [0.05077765, -0.003994, -0.00984688, -0.09356729, -0.09648388],
+            [-0.19183453, 0.11952393, 0.000561, 0.14462118, 0.34114323]]
+        samples_df = pd.DataFrame(np.array(noise),
+                                  index=['A', 'B', 'C', 'D'],
+                                  columns=axes[:5])
+        self.expected_noise = skbio.OrdinationResults(
+                'PCoA',
+                'Principal Coordinate Analysis',
+                eigvals[:5].copy(),
+                samples_df.copy(),
+                proportion_explained=proportion_explained[:5].copy())
+
         self.expected_m2 = 0.72240956
         self.expected_p = 0.5
 
@@ -93,6 +108,45 @@ class PCoATests(unittest.TestCase):
 
         self.assertAlmostEqual(true_m2, self.expected_m2)
         self.assertNotAlmostEqual(true_p_value, self.expected_p)
+
+    def test_non_zero_p(self):
+        # generated with np.random.seed(3); np.random.randn(4, 6)
+        noise = np.array(
+            [[1.78862847, 0.43650985, 0.09649747, -1.8634927, -0.2773882,
+              -0.35475898],
+             [-0.08274148, -0.62700068, -0.04381817, -0.47721803, -1.31386475,
+              0.88462238],
+             [0.88131804, 1.70957306, 0.05003364, -0.40467741, -0.54535995,
+              -1.54647732],
+             [0.98236743, -1.10106763, -1.18504653, -0.2056499, 1.48614836,
+              0.23671627]])
+        self.other.samples += noise
+
+        ref, other, m2_results = procrustes_analysis(self.reference,
+                                                     self.other)
+
+        true_m2 = m2_results['true M^2 value'][0]
+        true_p_value = m2_results['p-value for true M^2 value'][0]
+
+        skbio.util.assert_ordination_results_equal(ref, self.expected_ref)
+        skbio.util.assert_ordination_results_equal(other, self.expected_noise)
+
+        # the p value shouldn't be zero even in the presence of noise
+        self.assertAlmostEqual(true_m2, 0.7388121)
+        self.assertNotAlmostEqual(true_p_value, 0.001)
+
+    def test_zero_permutations_nan_pvalue(self):
+        ref, other, m2_results = procrustes_analysis(self.reference,
+                                                     self.other,
+                                                     permutations=0)
+        true_m2 = m2_results['true M^2 value'][0]
+        true_p_value = m2_results['p-value for true M^2 value'][0]
+
+        skbio.util.assert_ordination_results_equal(ref, self.expected_ref)
+        skbio.util.assert_ordination_results_equal(other, self.expected_other)
+
+        self.assertAlmostEqual(true_m2, self.expected_m2)
+        self.assertTrue(np.isnan(true_p_value))
 
     def test_procrustes_bad_dimensions(self):
 


### PR DESCRIPTION
- Adds a permutations parameter.
- Add handling for zero permutations.
- Avoid returning p-value=0 to mimic the behaviour of other
  permutation-based tests.
- Rename trials to permutations.