### PR TITLE
maint: new pandas groupby api

### DIFF
--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -458,7 +458,9 @@ class ReindexWithMetadataTests(unittest.TestCase):
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'peanut', 'russ'], name='pet')
-        exp = pd.DataFrame(data=[[5, 6, 7, 8], [9, 10, 11, 12], [1, 2, 3, 4]],
+        exp = pd.DataFrame(data=[[5.0, 6.0, 7.0, 8.0],
+                                 [9.0, 10.0, 11.0, 12.0],
+                                 [1.0, 2.0, 3.0, 4.0]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, median)
@@ -482,7 +484,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'russ'], name='pet')
-        exp = pd.DataFrame(data=[[5, 6, 7, 8], [5, 6, 7, 8]],
+        exp = pd.DataFrame(data=[[5.0, 6.0, 7.0, 8.0], [5.0, 6.0, 7.0, 8.0]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, median)
@@ -506,7 +508,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['russ'], name='pet')
-        exp = pd.DataFrame(data=[[5, 6, 7, 8]],
+        exp = pd.DataFrame(data=[[5.0, 6.0, 7.0, 8.0]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, median)
@@ -532,7 +534,9 @@ class ReindexWithMetadataTests(unittest.TestCase):
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'peanut', 'russ'], name='pet')
-        exp = pd.DataFrame(data=[[5, 6, 7, 8], [9, 10, 11, 12], [1, 2, 3, 4]],
+        exp = pd.DataFrame(data=[[5.0, 6.0, 7.0, 8.0],
+                                 [9.0, 10.0, 11.0, 12.0],
+                                 [1.0, 2.0, 3.0, 4.0]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, median)
@@ -545,7 +549,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
         median, counts = _reindex_with_metadata('toy', ['pet', 'toy'], data)
 
         exp_ind = pd.Index(['stick', 'yeti'], name='toy')
-        exp = pd.DataFrame(data=[[5, 6, 7, 8], [5, 6, 7, 8]],
+        exp = pd.DataFrame(data=[[5.0, 6.0, 7.0, 8.0], [5.0, 6.0, 7.0, 8.0]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, median)


### PR DESCRIPTION
https://pandas.pydata.org/docs/whatsnew/v1.3.0.html#float-result-for-groupby-mean-groupby-median-and-groupby-var

All groupby operations now return floats. Older versions of the `alpha-rarefaction` viz would return a mix of floats and ints, so this seems nicer all around.