### PR TITLE
Closes `plt.Figure()` after saving mantel test plot to free up memory

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -333,6 +333,7 @@ def mantel(output_dir: str, dm1: skbio.DistanceMatrix,
     scatter_data = pd.DataFrame(scatter_data, columns=[x, y])
     sns.regplot(x=x, y=y, data=scatter_data, fit_reg=False)
     plt.savefig(os.path.join(output_dir, 'mantel-scatter.svg'))
+    plt.close()
 
     context = {
         'table': table_html,


### PR DESCRIPTION
In the code, beta correlation `mantel()` in `_visualizer.py` opens an instance of `plt.Figure()` and doesn't close it, consuming memory. Added a line to close the instance and free up memory after saving. 
