### PR TITLE
ENH/API: support coloring Mantel scatters

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -323,12 +323,12 @@ def mantel(output_dir: str, dm1: skbio.DistanceMatrix,
 
     # if we have metadata, construct a lookup to easily determine the category
     # a sample is associated with
-    metadata = metadata.filter_ids(dm1.ids)
-    metadata = metadata.drop_missing_values()
     if metadata is None:
         metadata = pd.Series(['single-group'] * len(dm1.ids),
                              index=list(dm1.ids))
     else:
+        metadata = metadata.filter_ids(dm1.ids)
+        metadata = metadata.drop_missing_values()
         metadata = metadata.to_series()
     metadata = metadata.to_dict()
 

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -586,6 +586,7 @@ plugin.visualizers.register_function(
     parameters={'permutations': Int % Range(0, None),
                 'method': Str % Choices(['spearman', 'pearson']),
                 'intersect_ids': Bool,
+                'metadata': MetadataColumn[Categorical],
                 'label1': Str,
                 'label2': Str},
     name='Apply the Mantel test to two distance matrices',
@@ -615,6 +616,7 @@ plugin.visualizers.register_function(
                          'distance matrices will be discarded before applying '
                          'the Mantel test. Default behavior is to error on '
                          'any mismatched IDs.',
+        'metadata': 'A categorical variable to color the scatter plot by',
         'label1': 'Label for `dm1` in the output visualization.',
         'label2': 'Label for `dm2` in the output visualization.'
     },


### PR DESCRIPTION
This pull request introduces a means to color the Mantel scatter plots by a categorical variable, which can help emphasize structure in the plot. An example is attached
![Screen Shot 2021-10-27 at 4 12 58 PM](https://user-images.githubusercontent.com/474290/139160593-d1225503-c645-4f18-9f97-82a482cf48e2.png)


