### PR TITLE
Citation updates/DOI adds

### DIFF
--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -141,7 +141,8 @@
   number={260},
   pages={583--621},
   year={1952},
-  publisher={Taylor \& Francis}
+  publisher={Taylor \& Francis},
+  doi = {10.1080/01621459.1952.10483441},
 }
 
 @article{anderson2001new,

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -175,7 +175,8 @@
   volume={58},
   pages={240--242},
   year={1895},
-  publisher={JSTOR}
+  publisher={JSTOR},
+  doi={https://doi.org/10.1098/rspl.1895.0041}
 }
 
 @article{spearman1904proof,

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -129,7 +129,8 @@
   journal={Marine ecology progress series},
   pages={205--219},
   year={1993},
-  publisher={JSTOR}
+  publisher={JSTOR},
+  doi={https://doi.org/10.3354/meps092205}
 }
 
 @article{kruskal1952use,

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -187,7 +187,8 @@
   number={1},
   pages={72--101},
   year={1904},
-  publisher={JSTOR}
+  publisher={JSTOR},
+  doi={https://doi.org/10.2307/1422689}
 }
 
 @inbook{legendrelegendre,

--- a/q2_diversity/citations.bib
+++ b/q2_diversity/citations.bib
@@ -1,10 +1,16 @@
-@article{halko2010,
-  title={An algorithm for the principal component analysis of large data sets},
-  author={Halko, Nathan and Martinsson, Per-Gunnar and Shkolnisky, Yoel and Tygert, Mark},
-  journal={arXiv e-prints},
-  year={2010},
-  eid={arXiv:1007.5510},
-  eprint={1007.5510}
+@article{halko2011,
+	title = {An Algorithm for the Principal Component Analysis of Large Data Sets},
+	copyright = {Copyright © 2011 Society for Industrial and Applied Mathematics},
+	url = {https://epubs.siam.org/doi/abs/10.1137/100804139},
+	doi = {10.1137/100804139},
+	abstract = {Recently popularized randomized methods for principal component analysis (PCA) efficiently and reliably produce nearly optimal accuracy—even on parallel processors—unlike the classical (deterministic) alternatives. We adapt one of these randomized methods for use with data sets that are too large to be stored in random-access memory (RAM). (The traditional terminology is that our procedure works efficiently out-of-core.) We illustrate the performance of the algorithm via several numerical examples. For example, we report on the PCA of a data set stored on disk that is so large that less than a hundredth of it can fit in our computer's RAM.},
+	language = {en},
+	urldate = {2022-02-22},
+	journal = {SIAM Journal on Scientific Computing},
+	author = {Halko, Nathan and Martinsson, Per-Gunnar and Shkolnisky, Yoel and Tygert, Mark},
+	month = {oct},
+	year = {2011},
+	note = {Publisher: Society for Industrial and Applied Mathematics},
 }
 
 @article{mcdonald2018unifrac,

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -214,7 +214,7 @@ plugin.methods.register_function(
     name='Principal Coordinate Analysis',
     description=("Apply principal coordinate analysis."),
     citations=[citations['legendrelegendre'],
-               citations['halko2010']]
+               citations['halko2011']]
 )
 
 plugin.methods.register_function(


### PR DESCRIPTION
Our Halko citation is from [arxiv](https://arxiv.org/abs/1007.5510). Looks like it was published in [SIAM](https://epubs.siam.org/doi/epdf/10.1137/100804139) the following year. Is general best practice to move to the peer-reviewed pub when we notice this?

I've been thinking about DOIs a bit lately, so added DOI fields for a few commonly-used resources. I haven't updated the citation keys for those or anything - that's OK, right?