### PR TITLE
pin: R 4.2.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     # `emperor` and this comment can be removed.
     - q2-emperor {{ qiime2_epoch }}.*
     - q2-diversity-lib {{ qiime2_epoch }}.*
+    - r-base >=4.2.0
     - r-vegan >=2.5_3
     - umap-learn
 


### PR DESCRIPTION
this PR min pins r-base at 4.2.0 to ensure compatibility across the QIIME 2 ecosystem with R 4.2.0 to accommodate ANCOM-BC, since this is now being wrapped within q2-composition.
