### PR TITLE
dep: adding r-base

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     # `emperor` and this comment can be removed.
     - q2-emperor {{ qiime2_epoch }}.*
     - q2-diversity-lib {{ qiime2_epoch }}.*
-    - r-base >=4.2.0
+    - r-base {{ r-base }}
     - r-vegan >=2.5_3
     - umap-learn
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     # `emperor` and this comment can be removed.
     - q2-emperor {{ qiime2_epoch }}.*
     - q2-diversity-lib {{ qiime2_epoch }}.*
+    - r-base >=4.2.0
     - r-vegan >=2.5_3
     - umap-learn
 


### PR DESCRIPTION
this pin adds the global r-base requirement as a requirement for diversity, to keep the required version of R up to date.