### PR TITLE
ENH: Add partial Procrustes support

### DIFF
--- a/q2_diversity/__init__.py
+++ b/q2_diversity/__init__.py
@@ -12,7 +12,7 @@ from ._beta import (beta, beta_phylogenetic, bioenv,
                     beta_group_significance, mantel, beta_rarefaction,
                     beta_correlation, adonis)
 from ._ordination import pcoa, pcoa_biplot, tsne, umap
-from ._procrustes import procrustes_analysis
+from ._procrustes import procrustes_analysis, partial_procrustes
 from ._core_metrics import core_metrics_phylogenetic, core_metrics
 from ._filter import filter_distance_matrix
 from ._version import get_versions
@@ -27,5 +27,5 @@ __all__ = ['beta', 'beta_phylogenetic', 'alpha', 'alpha_phylogenetic',
            'core_metrics_phylogenetic', 'core_metrics',
            'filter_distance_matrix', 'mantel', 'alpha_rarefaction',
            'beta_rarefaction', 'procrustes_analysis', 'beta_correlation',
-           'adonis',
+           'adonis', 'partial_procrustes'
            ]

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -117,11 +117,9 @@ def _procrustes_monte_carlo(reference: np.ndarray, other: np.ndarray,
     return df
 
 
-def deconstructed_procrustes(mtx1: np.array,
-                             mtx2: np.array) -> (np.ndarray, np.ndarray,
-                                                 float, float, np.ndarray,
-                                                 float):
-    """Derived from scipy procrustes."""
+def _deconstructed_procrustes(mtx1, mtx2):
+    # Derived from scipy procrustes
+    # https://github.com/scipy/scipy/blob/d541c752246a9e196034957d3e044950eec75907/scipy/spatial/_procrustes.py#L100-L125
     mtx1 = mtx1.copy()
     mtx2 = mtx2.copy()
 
@@ -147,10 +145,7 @@ def deconstructed_procrustes(mtx1: np.array,
     return mtx1_translate, mtx2_translate, norm1, norm2, R, s
 
 
-def partial_procrustes(df_mtx1: pd.DataFrame,
-                       df_mtx2: pd.DataFrame,
-                       df_mtx1_pair_ids: list,
-                       df_mtx2_pair_ids: list) -> (pd.DataFrame, pd.DataFrame):
+def _partial_procrustes(df_mtx1, df_mtx2, df_mtx1_pair_ids, df_mtx2_pair_ids):
     df_mtx1 = df_mtx1.copy()
     df_mtx2 = df_mtx2.copy()
 
@@ -159,7 +154,7 @@ def partial_procrustes(df_mtx1: pd.DataFrame,
     paired_mtx2 = df_mtx2.loc[df_mtx2_pair_ids]
 
     # compute procrustes on paired data
-    results = deconstructed_procrustes(paired_mtx1, paired_mtx2)
+    results = _deconstructed_procrustes(paired_mtx1, paired_mtx2)
     mtx1_translate, mtx2_translate, norm1, norm2, R, s = results
 
     # transform both full input matrices

--- a/q2_diversity/_procrustes.py
+++ b/q2_diversity/_procrustes.py
@@ -162,6 +162,7 @@ def partial_procrustes(reference: OrdinationResults, other: OrdinationResults,
             .copy())
     return out
 
+
 def _deconstructed_procrustes(mtx1, mtx2):
     # Derived from scipy procrustes
     # https://github.com/scipy/scipy/blob/d541c752246a9e196034957d3e044950eec75907/scipy/spatial/_procrustes.py#L100-L125

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -377,8 +377,7 @@ plugin.methods.register_function(
     parameter_descriptions={
         'dimensions': ('The number of dimensions to use when fitting the two '
                        'matrices'),
-        'pairing': ("The metadata column describing the pair a sample may "
-                    "sample pairs.")
+        'pairing': ("The metadata column describing sample pairs which exist.")
     },
     output_descriptions={
         'transformed': ("The 'other' ordination transformed into the space of "

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -357,6 +357,39 @@ plugin.methods.register_function(
     description='Fit two ordination matrices with Procrustes analysis'
 )
 
+plugin.methods.register_function(
+    function=q2_diversity.partial_procrustes,
+    inputs={'reference': PCoAResults,
+            'other': PCoAResults,
+    },
+    parameters={
+        'dimensions': Int % Range(1, None),
+        'pairing': MetadataColumn[Categorical],
+    },
+    outputs=[
+        ('transformed', PCoAResults),
+    ],
+    input_descriptions={
+        'reference': ('The ordination matrix to which data is fitted to.'),
+        'other': ("The ordination matrix that's fitted to the reference "
+                  "ordination."),
+    },
+    parameter_descriptions={
+        'dimensions': ('The number of dimensions to use when fitting the two '
+                       'matrices'),
+        'pairing': ("The metadata column describing the pair a sample may "
+                    "sample pairs.")
+    },
+    output_descriptions={
+        'transformed': ("The 'other' ordination transformed into the space of "
+                        "the reference ordination."),
+    },
+    name='Partial Procrustes',
+    description=('Transform one ordination into another, using paired samples '
+                 'to anchor the transformation. This method allows does not '
+                 'require all samples to be paired.')
+)
+
 plugin.pipelines.register_function(
     function=q2_diversity.core_metrics_phylogenetic,
     inputs={

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -359,8 +359,9 @@ plugin.methods.register_function(
 
 plugin.methods.register_function(
     function=q2_diversity.partial_procrustes,
-    inputs={'reference': PCoAResults,
-            'other': PCoAResults,
+    inputs={
+        'reference': PCoAResults,
+        'other': PCoAResults,
     },
     parameters={
         'dimensions': Int % Range(1, None),

--- a/q2_diversity/tests/test_procrustes.py
+++ b/q2_diversity/tests/test_procrustes.py
@@ -14,8 +14,8 @@ import numpy.testing as npt
 import pandas as pd
 
 from q2_diversity import procrustes_analysis
-from q2_diversity._procrustes import  (_deconstructed_procrustes,
-                                       _partial_procrustes)
+from q2_diversity._procrustes import (_deconstructed_procrustes,
+                                      _partial_procrustes)
 
 
 class PartialProcrustesTests(unittest.TestCase):
@@ -58,8 +58,7 @@ class PartialProcrustesTests(unittest.TestCase):
                           [-np.cos(shiftangle),
                            -np.sin(shiftangle)],
                           [-np.cos(np.pi / 2 - shiftangle),
-                           -np.sin(np.pi / 2 - shiftangle)]],
-                          'd') / np.sqrt(4)
+                           -np.sin(np.pi / 2 - shiftangle)]], 'd') / np.sqrt(4)
         result = _deconstructed_procrustes(data1, data2)
         a, b, disparity = self._complete_procrustes(data1, data2, *result)
         npt.assert_allclose(b, a)


### PR DESCRIPTION
Co-authored-by: @wasade

Adds support for a modified Procrustes analysis wherein a computed transformation can be fit on two ordinations and then applied to additional points. We envision this being used, for example, to compare paired samples sequenced with WGS and 16S.

On the Q2 interface, we are thinking of adding a parameter to `qiime diversity procrustes-analysis` that can disable strictness on ID overlap. Additional things to consider are modifying the visualization to show (a) M^2 by increasing number of paired samples used and (b) before/after Pearson correlation of PC1/PC2/PC3 for the paired samples.

Daniel has used the code added in the initial commit to some encouraging preliminary success. Below is an example of a subset of 200 paired samples (out of 800 total) upon which both WGS and 16S were performed.

![image](https://user-images.githubusercontent.com/4030868/211675886-64b7bb93-29b1-417e-a8ed-153ad0e01b10.png)

![image](https://user-images.githubusercontent.com/4030868/211675827-ac156954-d26d-4cb9-8b74-48a2216dbc13.png)

