### PR TITLE
BUG: fixed swapped labels for beta_correlation action

### DIFF
--- a/q2_diversity/_beta/_beta_correlation.py
+++ b/q2_diversity/_beta/_beta_correlation.py
@@ -7,10 +7,10 @@
 # ----------------------------------------------------------------------------
 
 
-def beta_correlation(ctx, metadata, distance_matrix,
+def beta_correlation(ctx, distance_matrix, metadata,
                      method="spearman", permutations=999,
-                     intersect_ids=False, label1='Metadata',
-                     label2='Distance Matrix'):
+                     intersect_ids=False, label1='Distance Matrix',
+                     label2='Metadata'):
 
     convert_to_dist_matrix = ctx.get_action('metadata', 'distance_matrix')
     mantel = ctx.get_action('diversity', 'mantel')

--- a/q2_diversity/tests/test_beta_correlation.py
+++ b/q2_diversity/tests/test_beta_correlation.py
@@ -35,10 +35,10 @@ class BetaCorrelationTests(TestPluginBase):
 
     def test_execution(self):
         # does it run?
-        self.beta_correlation(self.md, self.dm)
+        self.beta_correlation(self.dm, self.md)
 
     def test_outputs(self):
-        result = self.beta_correlation(self.md, self.dm)
+        result = self.beta_correlation(self.dm, self.md)
         # correct number of outputs?
         self.assertEqual(2, len(result))
         # correct types?


### PR DESCRIPTION
Fixes labels for beta_correlations so that it correctly labels the metadata axis and the distance matrix axis.