### PR TITLE
BUG: fix bioenv erroring on MD columns without any data

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -44,7 +44,7 @@ def bioenv(output_dir: str, distance_matrix: skbio.DistanceMatrix,
     # Drop samples that have any missing values.
     # TODO use Metadata API if more filtering is supported in the future.
     df = metadata.to_dataframe()
-    df = df.dropna()
+    df = df.dropna(axis=1)
     metadata = qiime2.Metadata(df)
 
     # filter 0 variance numerical columns and empty columns

--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -36,41 +36,34 @@ def bioenv(output_dir: str, distance_matrix: skbio.DistanceMatrix,
     # Also ensures every distance matrix ID is present in the metadata.
     metadata = metadata.filter_ids(distance_matrix.ids)
 
-    # drop non-numeric columns and empty columns
+    # drop non-numeric columns
     pre_filtered_cols = set(metadata.columns)
     metadata = metadata.filter_columns(column_type='numeric')
     non_numeric_cols = pre_filtered_cols - set(metadata.columns)
 
-    # Drop samples that have any missing values.
-    # TODO use Metadata API if more filtering is supported in the future.
+    # Drop cols with any empty values so we're only retaining dense columns.
+    # TODO: use Metadata API if more filtering is supported in the future.
     df = metadata.to_dataframe()
+    all_cols = set(df.columns)
     df = df.dropna(axis=1)
+    missing_values_cols = all_cols - set(df.columns)
     metadata = qiime2.Metadata(df)
 
-    # filter 0 variance numerical columns and empty columns
+    # filter 0 variance numerical columns
     pre_filtered_cols = set(metadata.columns)
-    metadata = metadata.filter_columns(drop_zero_variance=True,
-                                       drop_all_missing=True)
+    metadata = metadata.filter_columns(drop_zero_variance=True)
     zero_variance_cols = pre_filtered_cols - set(metadata.columns)
 
     df = metadata.to_dataframe()
-
-    # filter the distance matrix to exclude samples that were dropped from
-    # the metadata, and keep track of how many samples survived the filtering
-    # so that information can be presented to the user.
-    initial_dm_length = distance_matrix.shape[0]
-    distance_matrix = distance_matrix.filter(df.index)
-    filtered_dm_length = distance_matrix.shape[0]
 
     result = skbio.stats.distance.bioenv(distance_matrix, df)
     result = q2templates.df_to_html(result)
 
     index = os.path.join(TEMPLATES, 'bioenv_assets', 'index.html')
     q2templates.render(index, output_dir, context={
-        'initial_dm_length': initial_dm_length,
-        'filtered_dm_length': filtered_dm_length,
         'non_numeric_cols': ', '.join(sorted(non_numeric_cols)),
         'zero_variance_cols': ', '.join(sorted(zero_variance_cols)),
+        'missing_values_cols': ', '.join(sorted(missing_values_cols)),
         'result': result})
 
 

--- a/q2_diversity/_beta/bioenv_assets/index.html
+++ b/q2_diversity/_beta/bioenv_assets/index.html
@@ -3,26 +3,25 @@
 {% block content %}
     {% if non_numeric_cols %}
       <div class="alert alert-warning col-md-12">
-        The following metadata columns have been omitted because the metadata
-        column was not numeric:
+        The following metadata column(s) have been omitted
+        because they were not numeric:
         <strong>{{ non_numeric_cols }}</strong>
       </div>
     {% endif %}
     {% if zero_variance_cols %}
       <div class="alert alert-warning col-md-12">
-        The following metadata columns have been omitted because the metadata
-        column had no variance, or consisted only of missing values:
+        The following metadata column(s) have been omitted
+        because they had no variance:
         <strong>{{ zero_variance_cols }}</strong>
       </div>
     {% endif %}
-    {% if initial_dm_length != filtered_dm_length %}
-      <p class="alert alert-warning">
-        <b>Warning</b>: Some samples were filtered from the input distance matrix
-        because they were missing metadata values.<br><b>The input distance matrix
-        contained {{ initial_dm_length }} samples but bioenv was computed on only
-        {{ filtered_dm_length }} samples.
-      </p>
-    {% endif %}
+    {% if missing_values_cols %}
+    <div class="alert alert-warning col-md-12">
+      The following metadata column(s) have been omitted
+      because they contained missing values:
+      <strong>{{ missing_values_cols }}</strong>
+    </div>
+  {% endif %}
     <div class="row">
         <div class="col-lg-12">
             {{ result }}

--- a/q2_diversity/tests/test_beta.py
+++ b/q2_diversity/tests/test_beta.py
@@ -402,18 +402,18 @@ class BioenvTests(TestPluginBase):
         with tempfile.TemporaryDirectory() as output_dir:
             bioenv(output_dir, self.dm, md)
             index_fp = os.path.join(output_dir, 'index.html')
+            html = open(index_fp).read()
 
             # assert that the html file exists
             self.assertTrue(os.path.exists(index_fp))
 
             # assert that metadata1 was found in the table
-            self.assertTrue('<th>metadata1</th>' in open(index_fp).read())
+            self.assertIn('<th>metadata1</th>', html)
 
             # assert that metadata2 was found in the alert div at the top
             # of the page in the list of excluded non-numeric cols
-            self.assertTrue(
-                '        because they were not numeric:\n'
-                '        <strong>metadata2</strong>' in open(index_fp).read())
+            self.assertIn('        because they were not numeric:\n'
+                          '        <strong>metadata2</strong>', html)
 
     def test_bioenv_exclude_missing_data_columns(self):
         md = qiime2.Metadata(
@@ -425,18 +425,18 @@ class BioenvTests(TestPluginBase):
         with tempfile.TemporaryDirectory() as output_dir:
             bioenv(output_dir, self.dm, md)
             index_fp = os.path.join(output_dir, 'index.html')
+            html = open(index_fp).read()
 
             # assert that the html file exists
             self.assertTrue(os.path.exists(index_fp))
 
             # assert that metadata1 was found in the table
-            self.assertTrue('<th>metadata1</th>' in open(index_fp).read())
+            self.assertIn('<th>metadata1</th>', html)
 
             # assert that metadata2 was found in the alert div at the top
             # of the page in the list of excluded cols w/missing vals
-            self.assertTrue(
-                '      because they contained missing values:\n'
-                '      <strong>metadata2</strong>' in open(index_fp).read())
+            self.assertIn('      because they contained missing values:\n'
+                          '      <strong>metadata2</strong>', html)
 
     def test_bioenv_exclude_zero_variance_columns(self):
         md = qiime2.Metadata(
@@ -448,18 +448,18 @@ class BioenvTests(TestPluginBase):
         with tempfile.TemporaryDirectory() as output_dir:
             bioenv(output_dir, self.dm, md)
             index_fp = os.path.join(output_dir, 'index.html')
+            html = open(index_fp).read()
 
             # assert that the html file exists
             self.assertTrue(os.path.exists(index_fp))
 
             # assert that metadata1 was found in the table
-            self.assertTrue('<th>metadata1</th>' in open(index_fp).read())
+            self.assertIn('<th>metadata1</th>', html)
 
             # assert that metadata2 was found in the alert div at the top
             # of the page in the list of excluded cols w/no variance
-            self.assertTrue(
-                '        because they had no variance:\n'
-                '        <strong>metadata2</strong>' in open(index_fp).read())
+            self.assertIn('        because they had no variance:\n'
+                          '        <strong>metadata2</strong>', html)
 
 
 class BetaGroupSignificanceTests(unittest.TestCase):


### PR DESCRIPTION
Fixes: #320 

For context, this was originally introduced by issue #275 (linked PR #276). I'm a bit surprised that the initial fix didn't involve dropping the empty columns (vs. dropping the rows with any empty values).

From the OP's example data, here's the resultant viz after dropping empty columns from their data:
![Screen Shot 2024-07-09 at 4 50 48 PM](https://github.com/qiime2/q2-diversity/assets/54517601/19962d58-089b-4f6b-bbe6-5c71055cf02c)

I'll need to take a closer look at what the expected output should be to see if this is actually a reasonable fix.