### PR TITLE
MAINT: remove `node_modules` from conda pkg build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ include = ["q2_diversity*"]
 
 [tool.setuptools.package-data]
 q2_diversity = ["**/*"]
+
+[tool.setuptools.exclude-package-data]
+q2_diversity = ["**/node_modules/**"]


### PR DESCRIPTION
PR xref that prompted this change: https://github.com/qiime2/q2-composition/pull/150