### PR TITLE
BUG: fix missing metadata handling after pandas update

### DIFF
--- a/q2_diversity/_alpha/_visualizer.py
+++ b/q2_diversity/_alpha/_visualizer.py
@@ -242,7 +242,11 @@ def alpha_correlation(output_dir: str,
 
 
 def _reindex_with_metadata(column, columns, merged):
-    reindexed = merged.set_index(column)
+    # Metadata columns are padded to a 2-level MultiIndex to align with the
+    # rarefaction data, and pandas preserves that tuple-shaped key on join.
+    metadata_key = (column, '_')
+    reindexed = merged.set_index(metadata_key)
+    reindexed.index.name = column
     reindexed.sort_index(axis=0, ascending=True, inplace=True)
     grouped = reindexed.groupby(level=[column])
     counts = grouped.count()

--- a/q2_diversity/tests/test_alpha_rarefaction.py
+++ b/q2_diversity/tests/test_alpha_rarefaction.py
@@ -101,6 +101,34 @@ class AlphaRarefactionTests(unittest.TestCase):
             with open(metric_fp) as metric_fh:
                 self.assertTrue('summer' not in metric_fh.read())
 
+    def test_alpha_rarefaction_with_partial_missing_metadata(self):
+        t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
+                       ['O1', 'O2'],
+                       ['S1', 'S2', 'S3'])
+        md = qiime2.Metadata(
+            pd.DataFrame({'pet': ['russ', np.nan, 'peanut']},
+                         index=pd.Index(['S1', 'S2', 'S3'], name='id')))
+        with tempfile.TemporaryDirectory() as output_dir:
+            alpha_rarefaction(
+                output_dir,
+                t,
+                metadata=md,
+                max_depth=200,
+                steps=2,
+                iterations=1
+            )
+            metric_fp = os.path.join(output_dir, 'shannon-pet.jsonp')
+            self.assertTrue(os.path.exists(metric_fp))
+            with open(metric_fp) as metric_fh:
+                jsonp_content = metric_fh.read()
+            prefix = "load_data('shannon', 'pet',"
+            self.assertTrue(jsonp_content.startswith(prefix))
+            self.assertTrue(jsonp_content.endswith(");"))
+            contents = pd.read_json(
+                io.StringIO(jsonp_content[len(prefix):-2]), orient='split')
+            self.assertEqual(['peanut', 'peanut', 'russ', 'russ'],
+                             list(contents['pet']))
+
     def test_alpha_rarefaction_with_filtered_metadata_columns(self):
         t = biom.Table(np.array([[100, 111, 113], [111, 111, 112]]),
                        ['O1', 'O2'],
@@ -507,7 +535,7 @@ class ComputeSummaryTests(unittest.TestCase):
 class ReindexWithMetadataTests(unittest.TestCase):
     def test_unique_metadata_groups(self):
         columns = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (200, 1),
-                                             (200, 2), ('pet', '')],
+                                             (200, 2), ('pet', '_')],
                                             names=['depth', 'iter'])
         data = pd.DataFrame(data=[[1, 2, 3, 4, 'russ'], [5, 6, 7, 8, 'milo'],
                                   [9, 10, 11, 12, 'peanut']],
@@ -515,7 +543,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
         median, counts = _reindex_with_metadata('pet', ['pet'], data)
 
-        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '']],
+        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '_']],
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'peanut', 'russ'], name='pet')
@@ -533,7 +561,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
     def test_some_duplicates_in_column(self):
         columns = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (200, 1),
-                                             (200, 2), ('pet', '')],
+                                             (200, 2), ('pet', '_')],
                                             names=['depth', 'iter'])
         data = pd.DataFrame(data=[[1, 2, 3, 4, 'russ'], [5, 6, 7, 8, 'milo'],
                                   [9, 10, 11, 12, 'russ']],
@@ -541,7 +569,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
         median, counts = _reindex_with_metadata('pet', ['pet'], data)
 
-        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '']],
+        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '_']],
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'russ'], name='pet')
@@ -557,7 +585,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
     def test_all_identical(self):
         columns = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (200, 1),
-                                             (200, 2), ('pet', '')],
+                                             (200, 2), ('pet', '_')],
                                             names=['depth', 'iter'])
         data = pd.DataFrame(data=[[1, 2, 3, 4, 'russ'], [5, 6, 7, 8, 'russ'],
                                   [9, 10, 11, 12, 'russ']],
@@ -565,7 +593,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
         median, counts = _reindex_with_metadata('pet', ['pet'], data)
 
-        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '']],
+        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '_']],
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['russ'], name='pet')
@@ -581,8 +609,8 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
     def test_multiple_columns(self):
         columns = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (200, 1),
-                                             (200, 2), ('pet', ''),
-                                             ('toy', '')],
+                                             (200, 2), ('pet', '_'),
+                                             ('toy', '_')],
                                             names=['depth', 'iter'])
         data = pd.DataFrame(data=[[1, 2, 3, 4, 'russ', 'stick'],
                                   [5, 6, 7, 8, 'milo', 'yeti'],
@@ -591,7 +619,7 @@ class ReindexWithMetadataTests(unittest.TestCase):
 
         median, counts = _reindex_with_metadata('pet', ['pet', 'toy'], data)
 
-        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet', 'toy'], [1, 2, '']],
+        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet', 'toy'], [1, 2, '_']],
                                 codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
                                 names=['depth', 'iter'])
         exp_ind = pd.Index(['milo', 'peanut', 'russ'], name='pet')
@@ -616,6 +644,32 @@ class ReindexWithMetadataTests(unittest.TestCase):
         pdt.assert_frame_equal(exp, median)
 
         exp = pd.DataFrame(data=[[2, 2, 2, 2], [1, 1, 1, 1]],
+                           columns=exp_col, index=exp_ind)
+
+        pdt.assert_frame_equal(exp, counts)
+
+    def test_missing_metadata_values_are_dropped(self):
+        columns = pd.MultiIndex.from_tuples([(1, 1), (1, 2), (200, 1),
+                                             (200, 2), ('pet', '_')],
+                                            names=['depth', 'iter'])
+        data = pd.DataFrame(data=[[1, 2, 3, 4, 'russ'],
+                                  [5, 6, 7, 8, np.nan],
+                                  [9, 10, 11, 12, 'peanut']],
+                            columns=columns, index=['S1', 'S2', 'S3'])
+
+        median, counts = _reindex_with_metadata('pet', ['pet'], data)
+
+        exp_col = pd.MultiIndex(levels=[[1, 200, 'pet'], [1, 2, '_']],
+                                codes=[[0, 0, 1, 1], [0, 1, 0, 1]],
+                                names=['depth', 'iter'])
+        exp_ind = pd.Index(['peanut', 'russ'], name='pet')
+        exp = pd.DataFrame(data=[[9., 10., 11., 12.],
+                                 [1., 2., 3., 4.]],
+                           columns=exp_col, index=exp_ind)
+
+        pdt.assert_frame_equal(exp, median)
+
+        exp = pd.DataFrame(data=[[1, 1, 1, 1], [1, 1, 1, 1]],
                            columns=exp_col, index=exp_ind)
 
         pdt.assert_frame_equal(exp, counts)


### PR DESCRIPTION
A tiny bit of fallout from the update in #392 (the `(c, '')` moved to `(c, '_')` which is necessary as pandas seems to simplify the former oddly. In fact it seems to have lived in a very ambiguous place, so the empty string was ignored by some methods.

Now that it gets standardized more uniformly, we need to use a real empty placeholder like `_`, but this has a few downstream impacts which weren't caught until we had missing metadata.