### PR TITLE
BUG: Update `run_adonis.R` to fix `n_jobs`

### DIFF
--- a/q2_diversity/_beta/adonis_assets/run_adonis.R
+++ b/q2_diversity/_beta/adonis_assets/run_adonis.R
@@ -24,7 +24,7 @@ distances <- read.table(file = args[[1]], sep="\t", header=TRUE, fill=TRUE, row.
 sample.md <- read.table(file = args[[2]], sep="\t", header=TRUE, fill=TRUE, row.names=1, quote="\"", na.strings="")
 formula <- args[[3]]
 perms <- as.integer(args[[4]])
-njobs <- args[[5]]
+njobs <- as.integer(args[[5]])
 out.path <- args[[6]]
 
 ### RUN ADONIS ###

--- a/q2_diversity/tests/test_adonis.py
+++ b/q2_diversity/tests/test_adonis.py
@@ -130,6 +130,17 @@ class AdonisTests(TestPluginBase):
             with tempfile.TemporaryDirectory() as temp_dir_name:
                 adonis(temp_dir_name, self.dm, md, 'letter+letter')
 
+    # addresses https://github.com/qiime2/q2-diversity/pull/394
+    def test_njobs_handled_as_integer(self):
+        md = qiime2.Metadata(pd.DataFrame(
+            [[1, 'a\'s'], [1, 'b\'s'], [2, 'b\'s'], [2, 'a\'s'], [3, 'c\'s']],
+            columns=['number', 'letter'],
+            index=pd.Index(['sample1', 'sample2', 'sample3',
+                            'sample4', 'sample5'], name='id')))
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            adonis(temp_dir_name, distance_matrix=self.dm, metadata=md,
+                   formula='letter+number', n_jobs='8')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->

Updates `run_adonis.R` to fix `njobs` not being interpreted as an integer.

When ` --p-n-jobs` was provided to the adonis test (qiime2 2026.4), the following error was written into the log:

> Running external command line application. This may print messages to stdout and/or stderr.
> The command being run is below. This command cannot be manually re-run as it will depend on temporary files that no longer exist.
> 
> Command: run_adonis.R /tmp/tmp1zex290z/dm.tsv /tmp/tmp1zex290z/md.tsv TP+Intervention+Subject 999 4 /tmp/rachis-temp-1phawh3m/adonis.tsv
> 
> R version 4.5.2 (2025-10-31) 
> Loading required package: permute
> Error in 0.4 * nx/ncl : non-numeric argument to binary operator
> Calls: adonis2 ... permutest.cca -> do.call -> mclapply -> splitIndices
> 9: splitIndices(nperm, parallel)
> 8: mclapply(splitIndices(nperm, parallel), getFlapply, mc.cores = parallel, 
>        permutations = permutations, E = E, Q = Q, QZ = QZ, effects = effects, 
>        w = w, first = first, isPartial = isPartial, isCCA = isCCA, 
>        isDB = isDB, q = q, r = r)
> 7: do.call(rbind, mclapply(splitIndices(nperm, parallel), getFlapply, 
>        mc.cores = parallel, permutations = permutations, E = E, 
>        Q = Q, QZ = QZ, effects = effects, w = w, first = first, 
>        isPartial = isPartial, isCCA = isCCA, isDB = isDB, q = q, 
>        r = r))
> 6: permutest.cca(object, permutations = permutations, model = model, 
>        by = "terms", parallel = parallel)
> 5: permutest(object, permutations = permutations, model = model, 
>        by = "terms", parallel = parallel)
> 4: anovaCCAbyterm(object, permutations = permutations, model = model, 
>        parallel = parallel)
> 3: anova.cca(sol, permutations = perm, by = by, parallel = parallel)
> 2: anova(sol, permutations = perm, by = by, parallel = parallel)
> 1: adonis2(formula, by = "terms", data = sample.md, permutations = perms, 
>        parallel = njobs)
> Traceback (most recent call last):
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/q2cli/commands.py", line 573, in __call__
>     results = self._execute_action(
>               ^^^^^^^^^^^^^^^^^^^^^
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/q2cli/commands.py", line 645, in _execute_action
>     results = action(**arguments)
>               ^^^^^^^^^^^^^^^^^^^
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/rachis/sdk/action.py", line 371, in signature_wrapper
>     return wrapper(*bound.args, **bound.kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/rachis/sdk/action.py", line 294, in bound_callable
>     outputs = self._callable_executor_(
>               ^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/rachis/sdk/action.py", line 529, in _callable_executor_
>     ret_val = self._callable(output_dir=temp_dir, **view_args)
>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/q2_diversity/_beta/_visualizer.py", line 381, in adonis
>     _run_command(cmd)
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/site-packages/q2_diversity/_beta/_visualizer.py", line 407, in _run_command
>     subprocess.run(cmd, check=True)
>   File "/home/ty/miniforge3/envs/rachis-qiime2-2026.4/lib/python3.12/subprocess.py", line 571, in run
>     raise CalledProcessError(retcode, process.args,
> subprocess.CalledProcessError: Command '['run_adonis.R', '/tmp/tmp1zex290z/dm.tsv', '/tmp/tmp1zex290z/md.tsv', 'TP+Intervention+Subject', '999', '4', '/tmp/rachis-temp-1phawh3m/adonis.tsv']' returned non-zero exit status 1.
> 

Solution:
Instead of:
`njobs <- args[[5]]`
there should be:
`njobs <- as.integer(args[[5]])`

No errors were encountered when running  adonis with ` --p-n-jobs` after changes.

Accompanying unit test was added by @lizgehret.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.