### PR TITLE
Blocked permutations Adonis 2026.4

### DIFF
--- a/q2_diversity/_beta/_visualizer.py
+++ b/q2_diversity/_beta/_visualizer.py
@@ -348,7 +348,8 @@ def adonis(output_dir: str,
            metadata: qiime2.Metadata,
            formula: str,
            permutations: int = 999,
-           n_jobs: int = 1) -> None:
+           n_jobs: int = 1,
+           permutation_unit_column: str = None) -> None:
     if n_jobs == 0:
         n_jobs = get_available_cores()
 
@@ -363,13 +364,36 @@ def adonis(output_dir: str,
 
     # Validate formula
     terms = ModelDesc.from_formula(formula)
+    formula_columns = []
     for t in terms.rhs_termlist:
         for i in t.factors:
-            column = metadata.get_column(i.name())
+            column_name = i.name()
+            column = metadata.get_column(column_name)
+            formula_columns.append(column_name)
             if column.has_missing_values():
                 raise ValueError('adonis requires metadata columns with no '
                                  'NaN values (missing values in column `%s`.)'
                                  % (column.name, ))
+
+    permutation_target_column = None
+    if permutation_unit_column is not None:
+        unique_formula_columns = list(dict.fromkeys(formula_columns))
+
+        if len(unique_formula_columns) != 1:
+            raise ValueError('Unit-level label permutations require a formula '
+                             'with exactly one metadata column.')
+
+        permutation_target_column = unique_formula_columns[0]
+
+        if permutation_unit_column not in filtered_md.columns:
+            raise ValueError('permutation_unit_column must be a column in '
+                             'metadata. `%s` was not found.'
+                             % permutation_unit_column)
+
+        if filtered_md[permutation_unit_column].isna().any():
+            raise ValueError('permutation_unit_column must have no NaN '
+                             'values. Missing values were found in column '
+                             '`%s`.' % permutation_unit_column)
 
     # Run adonis
     results_fp = os.path.join(output_dir, 'adonis.tsv')
@@ -380,6 +404,12 @@ def adonis(output_dir: str,
         metadata.save(md_fp)
         cmd = ['run_adonis.R', dm_fp, md_fp, formula, str(permutations),
                str(n_jobs), results_fp]
+
+        if permutation_unit_column is not None:
+            cmd.extend(['--unit-label-permutations',
+                        permutation_unit_column,
+                        permutation_target_column])
+
         _run_command(cmd)
 
     # Visualize results

--- a/q2_diversity/_beta/adonis_assets/run_adonis.R
+++ b/q2_diversity/_beta/adonis_assets/run_adonis.R
@@ -32,8 +32,135 @@ out.path <- args[[6]]
 dm <- as.dist(distances)
 formula <- as.formula(paste("dm ~ ", formula))
 
-res <- adonis2(formula, by='terms', data=sample.md, permutations=perms, parallel=njobs)
+unit.col <- NULL
+target.col <- NULL
+use.unit.label.permutations <- FALSE
 
-write.table(res, out.path, sep="\t", append=F, quote=FALSE)
+optional.args <- character(0)
+
+if (length(args) > 6) {
+  optional.args <- args[7:length(args)]
+}
+
+unit.flag <- "--unit-label-permutations"
+unit.flag.idx <- match(unit.flag, optional.args)
+
+if (!is.na(unit.flag.idx)) {
+  use.unit.label.permutations <- TRUE
+
+  if (length(optional.args) < unit.flag.idx + 2) {
+    stop(paste(
+      unit.flag,
+      "requires two following arguments:",
+      "permutation unit column and permutation target column."
+    ))
+  }
+
+  unit.col <- optional.args[[unit.flag.idx + 1]]
+  target.col <- optional.args[[unit.flag.idx + 2]]
+}
+
+get_f_value <- function(aov.tab, term) {
+  if (!(term %in% rownames(aov.tab))) {
+    stop(paste("Target term not found in adonis2 table:", term))
+  }
+
+  if (!("F" %in% colnames(aov.tab))) {
+    stop("Expected F column not found in adonis2 result table.")
+  }
+
+  return(as.numeric(aov.tab[term, "F"]))
+}
+
+if (!use.unit.label.permutations) {
+
+  res <- adonis2(
+    formula,
+    by='terms',
+    data=sample.md,
+    permutations=perms,
+    parallel=njobs
+  )
+
+  write.table(res, out.path, sep="\t", append=F, quote=FALSE)
+
+} else {
+
+  if (!(unit.col %in% colnames(sample.md))) {
+    stop(paste("permutation unit column not found in metadata:", unit.col))
+  }
+
+  if (!(target.col %in% colnames(sample.md))) {
+    stop(paste("permutation target column not found in metadata:", target.col))
+  }
+
+  unit.ids <- unique(as.character(sample.md[[unit.col]]))
+
+  unit.labels <- lapply(unit.ids, function(unit.id) {
+    rows <- as.character(sample.md[[unit.col]]) == unit.id
+    values <- unique(sample.md[[target.col]][rows])
+
+    if (length(values) != 1) {
+      stop(paste(
+        "permutation target column must be constant within each unit.",
+        "Problematic unit:",
+        unit.id
+      ))
+    }
+
+    return(values[[1]])
+  })
+
+  unit.labels <- unlist(unit.labels, use.names=FALSE)
+  names(unit.labels) <- unit.ids
+
+  observed <- suppressMessages(suppressWarnings(adonis2(
+    formula,
+    by='terms',
+    data=sample.md,
+    permutations=1,
+    parallel=njobs
+  )))
+
+  observed.tab <- observed
+  observed.f <- get_f_value(observed.tab, target.col)
+
+  perm.f <- numeric(perms)
+
+  for (i in seq_len(perms)) {
+    shuffled.labels <- sample(
+      unit.labels,
+      size=length(unit.labels),
+      replace=FALSE
+    )
+
+    names(shuffled.labels) <- names(unit.labels)
+
+    perm.md <- sample.md
+    perm.md[[target.col]] <- shuffled.labels[
+      match(as.character(sample.md[[unit.col]]), names(shuffled.labels))
+    ]
+
+    perm.res <- suppressMessages(suppressWarnings(adonis2(
+      formula,
+      by='terms',
+      data=perm.md,
+      permutations=1,
+      parallel=njobs
+    )))
+
+    perm.f[[i]] <- get_f_value(perm.res, target.col)
+  }
+
+  custom.p <- (sum(perm.f >= observed.f) + 1) / (perms + 1)
+
+  if (!("Pr(>F)" %in% colnames(observed.tab))) {
+    stop("Expected Pr(>F) column not found in adonis2 result table.")
+  }
+
+  observed.tab[target.col, "Pr(>F)"] <- custom.p
+
+  write.table(observed.tab, out.path, sep="\t", append=F, quote=FALSE)
+}
 
 q(status=0)

--- a/q2_diversity/plugin_setup.py
+++ b/q2_diversity/plugin_setup.py
@@ -947,6 +947,7 @@ plugin.visualizers.register_function(
         'formula': Str,
         'permutations': Int % Range(1, None),
         'n_jobs': Threads,
+        'permutation_unit_column': Str,
     },
     input_descriptions={
         'distance_matrix': 'Matrix of distances between pairs of samples.'
@@ -964,7 +965,14 @@ plugin.visualizers.register_function(
                    'quotes to avoid unpleasant surprises.',
         'permutations': 'The number of permutations to be run when computing '
                         'p-values.',
-        'n_jobs': 'Number of parallel processes to run.'
+        'n_jobs': 'Number of parallel processes to run.',
+        'permutation_unit_column': 'Optional sample metadata column defining '
+                                   'the experimental units whose formula '
+                                   'labels should be permuted as whole units, '
+                                   'e.g. subject ID, patient ID, or repeated-'
+                                   'measures unit. When this option is used, '
+                                   'the formula must contain exactly one '
+                                   'tested metadata column.'
     },
     name='adonis PERMANOVA test for beta group significance',
     description=('Determine whether groups of samples are significantly '

--- a/q2_diversity/tests/test_adonis.py
+++ b/q2_diversity/tests/test_adonis.py
@@ -67,7 +67,8 @@ class AdonisTests(TestPluginBase):
 
     def test_adonis_handles_single_quotes_in_metadata(self):
         md = qiime2.Metadata(pd.DataFrame(
-            [[1, 'a\'s'], [1, 'b\'s'], [2, 'b\'s'], [2, 'a\'s'], [3, 'c\'s']],
+            [[1, 'a\'s'], [1, 'b\'s'], [2, 'b\'s'],
+             [2, 'a\'s'], [3, 'c\'s']],
             columns=['number', 'letter'],
             index=pd.Index(['sample1', 'sample2', 'sample3',
                             'sample4', 'sample5'], name='id')))
@@ -131,18 +132,17 @@ class AdonisTests(TestPluginBase):
             with tempfile.TemporaryDirectory() as temp_dir_name:
                 adonis(temp_dir_name, self.dm, md, 'letter+letter')
 
-
     # addresses https://github.com/qiime2/q2-diversity/pull/394
     def test_njobs_handled_as_integer(self):
         md = qiime2.Metadata(pd.DataFrame(
-            [[1, 'a\'s'], [1, 'b\'s'], [2, 'b\'s'], [2, 'a\'s'], [3, 'c\'s']],
+            [[1, 'a\'s'], [1, 'b\'s'], [2, 'b\'s'],
+             [2, 'a\'s'], [3, 'c\'s']],
             columns=['number', 'letter'],
             index=pd.Index(['sample1', 'sample2', 'sample3',
                             'sample4', 'sample5'], name='id')))
         with tempfile.TemporaryDirectory() as temp_dir_name:
             adonis(temp_dir_name, distance_matrix=self.dm, metadata=md,
                    formula='letter+number', n_jobs='8')
-
 
     def _unit_permutation_test_data(self):
         ids = ['sample1', 'sample2', 'sample3',
@@ -218,7 +218,8 @@ class AdonisTests(TestPluginBase):
     def test_permutation_unit_column_must_exist(self):
         dm, md = self._unit_permutation_test_data()
 
-        with self.assertRaisesRegex(ValueError, 'permutation_unit_column.*not'):
+        with self.assertRaisesRegex(
+                ValueError, 'permutation_unit_column.*not'):
             with tempfile.TemporaryDirectory() as temp_dir_name:
                 adonis(temp_dir_name, dm, md, 'treatment',
                        permutations=19,

--- a/q2_diversity/tests/test_adonis.py
+++ b/q2_diversity/tests/test_adonis.py
@@ -7,6 +7,7 @@
 # ----------------------------------------------------------------------------
 
 import unittest
+import subprocess
 import os
 import tempfile
 
@@ -130,6 +131,7 @@ class AdonisTests(TestPluginBase):
             with tempfile.TemporaryDirectory() as temp_dir_name:
                 adonis(temp_dir_name, self.dm, md, 'letter+letter')
 
+
     # addresses https://github.com/qiime2/q2-diversity/pull/394
     def test_njobs_handled_as_integer(self):
         md = qiime2.Metadata(pd.DataFrame(
@@ -140,6 +142,125 @@ class AdonisTests(TestPluginBase):
         with tempfile.TemporaryDirectory() as temp_dir_name:
             adonis(temp_dir_name, distance_matrix=self.dm, metadata=md,
                    formula='letter+number', n_jobs='8')
+
+
+    def _unit_permutation_test_data(self):
+        ids = ['sample1', 'sample2', 'sample3',
+               'sample4', 'sample5', 'sample6']
+
+        dm = skbio.DistanceMatrix(
+            [[0, 0.2, 0.3, 0.7, 0.8, 0.9],
+             [0.2, 0, 0.25, 0.75, 0.85, 0.95],
+             [0.3, 0.25, 0, 0.65, 0.7, 0.8],
+             [0.7, 0.75, 0.65, 0, 0.2, 0.3],
+             [0.8, 0.85, 0.7, 0.2, 0, 0.25],
+             [0.9, 0.95, 0.8, 0.3, 0.25, 0]],
+            ids=ids)
+
+        md = qiime2.Metadata(pd.DataFrame(
+            [['a', 'unit1'],
+             ['a', 'unit1'],
+             ['a', 'unit2'],
+             ['b', 'unit3'],
+             ['b', 'unit3'],
+             ['b', 'unit4']],
+            columns=['treatment', 'subject_id'],
+            index=pd.Index(ids, name='id')))
+
+        return dm, md
+
+    def test_adonis_with_permutation_unit_column(self):
+        dm, md = self._unit_permutation_test_data()
+
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            adonis(temp_dir_name, dm, md, 'treatment',
+                   permutations=19,
+                   permutation_unit_column='subject_id')
+
+            res = pd.read_csv(
+                os.path.join(temp_dir_name, 'adonis.tsv'),
+                sep='\t',
+                index_col=0)
+
+            self.assertIn('treatment', res.index)
+            self.assertIn('Pr(>F)', res.columns)
+            self.assertGreaterEqual(res.loc['treatment', 'Pr(>F)'], 0)
+            self.assertLessEqual(res.loc['treatment', 'Pr(>F)'], 1)
+
+    def test_unit_permutations_preserve_observed_statistics(self):
+        dm, md = self._unit_permutation_test_data()
+
+        with tempfile.TemporaryDirectory() as old_dir:
+            adonis(old_dir, dm, md, 'treatment', permutations=19)
+            old = pd.read_csv(
+                os.path.join(old_dir, 'adonis.tsv'),
+                sep='\t',
+                index_col=0)
+
+        with tempfile.TemporaryDirectory() as unit_dir:
+            adonis(unit_dir, dm, md, 'treatment',
+                   permutations=19,
+                   permutation_unit_column='subject_id')
+            unit = pd.read_csv(
+                os.path.join(unit_dir, 'adonis.tsv'),
+                sep='\t',
+                index_col=0)
+
+        observed_cols = ['Df', 'SumOfSqs', 'R2', 'F']
+
+        pdt.assert_series_equal(
+            old.loc['treatment', observed_cols],
+            unit.loc['treatment', observed_cols],
+            check_dtype=False,
+            check_names=False,
+            check_exact=False)
+
+    def test_permutation_unit_column_must_exist(self):
+        dm, md = self._unit_permutation_test_data()
+
+        with self.assertRaisesRegex(ValueError, 'permutation_unit_column.*not'):
+            with tempfile.TemporaryDirectory() as temp_dir_name:
+                adonis(temp_dir_name, dm, md, 'treatment',
+                       permutations=19,
+                       permutation_unit_column='fake_subject_id')
+
+    def test_unit_permutations_require_single_formula_column(self):
+        dm, md = self._unit_permutation_test_data()
+
+        with self.assertRaisesRegex(ValueError, 'exactly one metadata column'):
+            with tempfile.TemporaryDirectory() as temp_dir_name:
+                adonis(temp_dir_name, dm, md, 'treatment+subject_id',
+                       permutations=19,
+                       permutation_unit_column='subject_id')
+
+    def test_unit_permutations_require_constant_label_within_unit(self):
+        ids = ['sample1', 'sample2', 'sample3',
+               'sample4', 'sample5', 'sample6']
+
+        dm = skbio.DistanceMatrix(
+            [[0, 0.2, 0.3, 0.7, 0.8, 0.9],
+             [0.2, 0, 0.25, 0.75, 0.85, 0.95],
+             [0.3, 0.25, 0, 0.65, 0.7, 0.8],
+             [0.7, 0.75, 0.65, 0, 0.2, 0.3],
+             [0.8, 0.85, 0.7, 0.2, 0, 0.25],
+             [0.9, 0.95, 0.8, 0.3, 0.25, 0]],
+            ids=ids)
+
+        md = qiime2.Metadata(pd.DataFrame(
+            [['a', 'unit1'],
+             ['b', 'unit1'],
+             ['a', 'unit2'],
+             ['b', 'unit3'],
+             ['b', 'unit3'],
+             ['b', 'unit4']],
+            columns=['treatment', 'subject_id'],
+            index=pd.Index(ids, name='id')))
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            with tempfile.TemporaryDirectory() as temp_dir_name:
+                adonis(temp_dir_name, dm, md, 'treatment',
+                       permutations=19,
+                       permutation_unit_column='subject_id')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

Adds an optional `permutation_unit_column` parameter to the `adonis` visualizer.

When this parameter is provided, the tested formula labels are permuted at the experimental-unit level instead of independently at the sample level. This supports repeated-measures designs where the tested metadata label is constant within a subject, patient, mouse, or other repeated-measures unit, including cases with unequal numbers of samples per unit.

The default behavior is unchanged when `permutation_unit_column` is omitted.

This PR also adds tests for:
- successful unit-level label permutations
- preservation of observed adonis2 statistics
- missing permutation unit columns
- formulas with more than one metadata column when unit-level permutations are requested
- non-constant tested labels within a unit

# AI Disclosure

- [ ] NO AI USED.
- [x] AI USED.

# AI Usage Details

ChatGPT was used interactively to help reason through the implementation, debug local test failures, draft unit tests, and review command-line/git workflow steps. I reviewed the code, ran the implementation locally, validated the behavior with QIIME 2 commands, and ran the adonis test suite successfully.